### PR TITLE
fix: address multiple bugs found in code review

### DIFF
--- a/src/contexts/snapshot.ts
+++ b/src/contexts/snapshot.ts
@@ -19,7 +19,6 @@ import typeGuard from "@/typeGuard";
 let snapshots: ISnapshot[] = [];
 
 const saveSnapshot = (vpos: number) => {
-  console.log("save snapshot", vpos);
   snapshots.push({
     vpos,
     queue: structuredClone(queue),
@@ -32,14 +31,12 @@ const saveSnapshot = (vpos: number) => {
 };
 
 const restoreSnapshot = (vpos: number) => {
-  console.log("restore snapshot", vpos);
   const snapshot = getLatestSnapshot(vpos);
 
   if (!snapshot) throw new Error("snapshot not found");
   snapshots = snapshots.filter((s) => s.vpos <= snapshot.vpos);
   resetObjects();
   for (const obj of structuredClone(snapshot.drawObjects)) {
-    console.log(obj);
     resultHook(obj);
   }
   setQueue(structuredClone(snapshot.queue));
@@ -71,11 +68,9 @@ const getLatestSnapshotVpos = (vpos: number) => {
 const resultHook = (input: unknown) => {
   if (typeof input === "object") {
     if (typeGuard.IrShapeLiteral(input)) {
-      console.log("restore shape", input.options.__id);
       const shape = drawObjects.find((obj) => obj.__id === input.options.__id);
       return shape ?? new IrShape(input.options);
     } else if (typeGuard.IrTextLiteral(input)) {
-      console.log("restore text", input.options.__id);
       const text = drawObjects.find((obj) => obj.__id === input.options.__id);
       return text ?? new IrText(input.options);
     }

--- a/src/objects/object.ts
+++ b/src/objects/object.ts
@@ -97,10 +97,6 @@ abstract class IrObject {
       currentPos = { x: lastVal, y: lastQueue.current.y };
       targetPos = { x: input, y: lastQueue.target.y };
     }
-    console.log(
-      `mover-x: ${JSON.stringify(currentPos)} to ${JSON.stringify(targetPos)}`,
-      this.mover,
-    );
     this.__updateMoverQueue(lastQueue, currentPos, targetPos);
   }
 
@@ -149,10 +145,6 @@ abstract class IrObject {
       currentPos = { x: lastQueue.current.x, y: lastVal };
       targetPos = { x: lastQueue.target.x, y: input };
     }
-    console.log(
-      `mover-y: ${JSON.stringify(currentPos)} to ${JSON.stringify(targetPos)}`,
-      this.mover,
-    );
     this.__updateMoverQueue(lastQueue, currentPos, targetPos);
   }
 
@@ -208,17 +200,8 @@ abstract class IrObject {
   }
 
   set alpha(val: unknown) {
-    let value: number;
-    if (typeof val !== "number") {
-      value = Number(val) || 0;
-    } else if (val > 100) {
-      value = 100;
-    } else if (val < 0) {
-      value = 0;
-    } else {
-      value = val;
-    }
-    this.options.alpha = value;
+    const value = typeof val === "number" ? val : Number(val) || 0;
+    this.options.alpha = Math.max(0, Math.min(100, value));
     this.__modified = true;
   }
 

--- a/src/objects/shape.ts
+++ b/src/objects/shape.ts
@@ -141,7 +141,7 @@ class IrShape extends IrObject {
         this.__height / 2,
         0,
         0,
-        360,
+        Math.PI * 2,
       );
       context.fill();
     }

--- a/src/objects/text.ts
+++ b/src/objects/text.ts
@@ -165,9 +165,8 @@ class IrText extends IrObject {
   }
 
   __updateFont() {
-    getCanvas(
-      this.__id,
-    ).context.font = `normal 600 ${this.__size}px Arial, "ＭＳ Ｐゴシック", "MS PGothic", MSPGothic, MS-PGothic`;
+    getCanvas(this.__id).context.font =
+      `normal 600 ${this.__size}px Arial, "ＭＳ Ｐゴシック", "MS PGothic", MSPGothic, MS-PGothic`;
   }
 
   override __updateColor() {
@@ -205,10 +204,9 @@ class IrText extends IrObject {
     this.__updateColor();
     const { canvas, context } = getCanvas(this.__id);
     context.clearRect(0, 0, canvas.width, canvas.height);
+    context.save();
     if (this.__reverse) {
       context.scale(-1, -1);
-    } else {
-      context.scale(1, 1);
     }
     const lineOffset = this.parsedComment.lineOffset;
     context.font = parseFont(this.parsedComment.font, this.__size);
@@ -279,6 +277,7 @@ class IrText extends IrObject {
         leftOffset += getValue(item.width?.[index], 0);
       });
     }
+    context.restore();
     if (this.filter === "kasumi") {
       this.kasumi();
     }

--- a/src/utils/mt19937.ts
+++ b/src/utils/mt19937.ts
@@ -14,8 +14,8 @@ const __init_genrand = (seed: number): void => {
 
   while (mti < N) {
     mt[mti] =
-      0x6c078965 * ((mt[mti - 1] || 0) ^ ((mt[mti - 1] || 0) >>> 30)) + mti;
-    mt[mti] &= 0xffffffff;
+      (0x6c078965 * ((mt[mti - 1] || 0) ^ ((mt[mti - 1] || 0) >>> 30)) + mti) &
+      0xffffffff;
     mti++;
   }
 };
@@ -31,10 +31,10 @@ const __init_by_array = (seed: number[], length: number) => {
     const value = getNumber(mt[key1]);
     const lastValue = getNumber(mt[key1 - 1]);
     mt[key1] =
-      (value ^ ((lastValue ^ (lastValue >>> 30)) * 0x0019660d)) +
-      (seed[key2] || 0) +
-      key2;
-    mt[key1] &= 0xffffffff;
+      ((value ^ ((lastValue ^ (lastValue >>> 30)) * 0x0019660d)) +
+        (seed[key2] || 0) +
+        key2) &
+      0xffffffff;
     key1++;
     key2++;
 
@@ -53,8 +53,9 @@ const __init_by_array = (seed: number[], length: number) => {
   for (let i = 0; i < range; i++) {
     const value = getNumber(mt[key1]);
     const lastValue = getNumber(mt[key1 - 1]);
-    mt[key1] = (value ^ ((lastValue ^ (lastValue >>> 30)) * 0x5d588b65)) - key1;
-    mt[key1] &= 0xffffffff;
+    mt[key1] =
+      ((value ^ ((lastValue ^ (lastValue >>> 30)) * 0x5d588b65)) - key1) &
+      0xffffffff;
     key1++;
 
     if (key1 >= N) {

--- a/src/utils/number2color.ts
+++ b/src/utils/number2color.ts
@@ -3,7 +3,7 @@
  * @param input
  */
 const number2color = (input: number) => {
-  const hex = `000000${input.toString(16)}`.slice(-6);
+  const hex = `000000${(input & 0xffffff).toString(16)}`.slice(-6);
   return `#${hex}`;
 };
 

--- a/src/utils/sort.ts
+++ b/src/utils/sort.ts
@@ -4,8 +4,8 @@
  */
 const nativeSort = <T extends { [key: string]: unknown }>(key: string) => {
   return (a: T, b: T) => {
-    const left = a[key] || 0;
-    const right = b[key] || 0;
+    const left = a[key] ?? 0;
+    const right = b[key] ?? 0;
     if (left > right) {
       return 1;
     } else if (left < right) {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -48,7 +48,8 @@ const format = (
   for (const key of Object.keys(options)) {
     const value = options[key];
     const type = types[key];
-    if (value !== undefined && type !== "any" && typeof value !== type) {
+    if (!type || type === "any") continue;
+    if (value !== undefined && typeof value !== type) {
       if (type === "string") {
         options[key] = Core.format(value, "string");
       } else if (type === "number") {


### PR DESCRIPTION
## Summary
- **CR-1:** `number2color()` が負数で不正なCSS色 (`"#0000-1"`) を生成するバグを `& 0xFFFFFF` マスクで修正
- **CR-2:** `alpha` セッターが文字列入力時に 0-100 の範囲クランプをバイパスするバグを修正
- **CR-4:** ホットパス（mover x/y更新、スナップショット操作）での `console.log` + `JSON.stringify` を削除しパフォーマンス改善
- **CR-5:** `IrText.__draw()` に `context.save()/restore()` を追加し、Canvas transform の累積を防止
- **CR-8:** `nativeSort()` の `||` を `??` に変更し、falsy値（`0` 等）の誤変換を防止
- **CR-9:** `IrShape.__draw()` の `ellipse()` 最終引数を `360` → `Math.PI * 2` に修正（正しいラジアン値）
- **CR-10:** `format()` に `types` マップに存在しないキーの早期 `continue` を追加
- 既存の `mt19937.ts` の TS2532 エラーをビットマスク操作のインライン化で修正

## Test plan
- [x] `npx tsc --noEmit` 型チェック通過
- [x] `npx jest` 全テスト通過（rand テストで mt19937 の動作確認含む）
- [x] pre-commit hook (format, eslint, check-types, test) 全通過