### PR TITLE
fix: bump CI Node.js version from 18 to 22

### DIFF
--- a/.github/workflows/create-dev-build.yml
+++ b/.github/workflows/create-dev-build.yml
@@ -15,7 +15,7 @@ jobs:
       - name: setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 22.x
           registry-url: 'https://registry.npmjs.org'
       - name: init
         run: |

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v3
         with:
-          node-version: "18"
+          node-version: "22"
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node.js runtime version in CI/CD workflows from version 18 to version 22.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->