### PR TITLE
Apply bold text weight to rendering

### DIFF
--- a/src/__tests__/drawTextBold.test.ts
+++ b/src/__tests__/drawTextBold.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+
+import { resetCanvas } from "@/contexts/canvas";
+import { initConfig } from "@/definition/config";
+import { IrText } from "@/objects/text";
+import { setup } from "@/utils/setup";
+import { parseFont } from "@/utils/utils";
+
+type RecordedCanvasCall = {
+  method: "fillText" | "measureText";
+  font: string;
+  text: string;
+};
+
+const installCanvasMock = (records: RecordedCanvasCall[]) => {
+  let currentFont = "";
+  const context = {
+    clearRect: vi.fn(),
+    drawImage: vi.fn(),
+    fillRect: vi.fn(),
+    fillText: vi.fn((text: string) => {
+      records.push({ method: "fillText", font: currentFont, text });
+    }),
+    get font() {
+      return currentFont;
+    },
+    lineJoin: "round",
+    lineWidth: 4,
+    measureText: vi.fn((text: string) => {
+      records.push({ method: "measureText", font: currentFont, text });
+      return { width: text.length * (currentFont.includes("bold") ? 11 : 10) };
+    }),
+    restore: vi.fn(),
+    save: vi.fn(),
+    scale: vi.fn(),
+    set font(value: string) {
+      currentFont = value;
+    },
+    strokeRect: vi.fn(),
+    strokeStyle: "#000000",
+    strokeText: vi.fn(),
+    textAlign: "start",
+    textBaseline: "alphabetic",
+  } as unknown as CanvasRenderingContext2D;
+
+  vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockImplementation(((
+    contextId: string,
+  ) => {
+    if (contextId === "2d") return context;
+    return null;
+  }) as HTMLCanvasElement["getContext"]);
+};
+
+beforeEach(() => {
+  initConfig();
+  setup();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  resetCanvas();
+});
+
+test("parseFont applies bold weight to default and flash font templates", () => {
+  expect(parseFont("defont", 30, true)).toMatch(/^bold 30px /);
+  expect(parseFont("defont", 30, false)).not.toMatch(/^bold 30px /);
+  expect(parseFont("gulim", 30, true)).toContain("normal bold 30px");
+  expect(parseFont("simsun", 30, true)).toContain("normal bold 30px");
+});
+
+test("IrText uses bold font weight for measurement and drawing", () => {
+  const records: RecordedCanvasCall[] = [];
+  installCanvasMock(records);
+
+  new IrText({ text: "bold text", size: 30, bold: true });
+
+  const measuredFont = records.find(
+    ({ method }) => method === "measureText",
+  )?.font;
+  const drawnFont = records.find(({ method }) => method === "fillText")?.font;
+
+  expect(measuredFont).toContain("bold 30px");
+  expect(drawnFont).toContain("bold 30px");
+});
+
+test("IrText keeps normal font weight when bold is false", () => {
+  const records: RecordedCanvasCall[] = [];
+  installCanvasMock(records);
+
+  new IrText({ text: "normal text", size: 30, bold: false });
+
+  const measuredFont = records.find(
+    ({ method }) => method === "measureText",
+  )?.font;
+  const drawnFont = records.find(({ method }) => method === "fillText")?.font;
+
+  expect(measuredFont).not.toContain("bold 30px");
+  expect(drawnFont).not.toContain("bold 30px");
+});

--- a/src/objects/text.ts
+++ b/src/objects/text.ts
@@ -159,6 +159,7 @@ class IrText extends IrObject {
 
   set bold(val) {
     this.options.bold = val;
+    this.__updateFont();
     this.__modified = true;
   }
 
@@ -172,8 +173,11 @@ class IrText extends IrObject {
   }
 
   __updateFont() {
-    getCanvas(this.__id).context.font =
-      `normal 600 ${this.__size}px Arial, "ＭＳ Ｐゴシック", "MS PGothic", MSPGothic, MS-PGothic`;
+    getCanvas(this.__id).context.font = parseFont(
+      this.parsedComment.font,
+      this.__size,
+      this.options.bold,
+    );
   }
 
   override __updateColor() {
@@ -193,10 +197,14 @@ class IrText extends IrObject {
       this.__size = size;
     }
     this.__updateFont();
-    const result = measure(getCanvas(this.__id).context, {
-      ...this.parsedComment,
-      size: this.__size,
-    });
+    const result = measure(
+      getCanvas(this.__id).context,
+      {
+        ...this.parsedComment,
+        size: this.__size,
+      },
+      this.options.bold,
+    );
     this.__actualWidth = result.width;
     this.__actualHeight = result.height;
     // Expand canvas for kage shadow overflow (offset + blur radius)
@@ -221,7 +229,11 @@ class IrText extends IrObject {
       context.scale(-1, -1);
     }
     const lineOffset = this.parsedComment.lineOffset;
-    context.font = parseFont(this.parsedComment.font, this.__size);
+    context.font = parseFont(
+      this.parsedComment.font,
+      this.__size,
+      this.options.bold,
+    );
     context.globalAlpha = (100 - this.options.alpha) / 100;
     if (this.filter === "kage") {
       const offset = this.__kageShadowOffset();
@@ -241,7 +253,7 @@ class IrText extends IrObject {
     for (const item of this.parsedComment.content) {
       if (lastFont !== getValue(item.font, this.parsedComment.font)) {
         lastFont = getValue(item.font, this.parsedComment.font);
-        context.font = parseFont(lastFont, this.__size);
+        context.font = parseFont(lastFont, this.__size, this.options.bold);
       }
       if (item.type === "normal") {
         const lines = item.content.split(/[\n\r]/g);

--- a/src/utils/flashText.ts
+++ b/src/utils/flashText.ts
@@ -254,12 +254,17 @@ const parseFullStr = (string: string): commentContentItem[] => {
 const measure = (
   context: CanvasRenderingContext2D,
   comment: measureTextInput,
+  bold = false,
 ) => {
   const width_arr = [];
   let currentWidth = 0;
   for (const item of comment.content) {
     const widths = [];
-    context.font = parseFont(getValue(item.font, comment.font), comment.size);
+    context.font = parseFont(
+      getValue(item.font, comment.font),
+      comment.size,
+      bold,
+    );
     if (item.type === "normal") {
       const lines = item.content.replace(/\r\n?/g, "\n").split(/\n/);
       let count = 0;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -22,13 +22,27 @@ const getGlobalScope = (scopes: T_scope[]): T_scope | undefined => {
  * @param size
  * @returns
  */
-const parseFont = (font: commentFont, size: string | number): string => {
+const formatFontWeight = (font: string, bold: boolean): string => {
+  if (!bold) return font;
+  return font.replace(/^(\S+\s+)(?:\d+|bold)(\s+)/, "$1bold$2");
+};
+
+const parseFont = (
+  font: commentFont,
+  size: string | number,
+  bold = false,
+): string => {
   switch (font) {
     case "gulim":
     case "simsun":
-      return config.font[font].replace("[size]", `${size}`);
+      return formatFontWeight(
+        config.font[font].replace("[size]", `${size}`),
+        bold,
+      );
     default:
-      return `${config.fonts.defont.weight} ${size}px ${config.fonts.defont.font}`;
+      return `${bold ? "bold" : config.fonts.defont.weight} ${size}px ${
+        config.fonts.defont.font
+      }`;
   }
 };
 


### PR DESCRIPTION
## Summary
- Threaded the `bold` option through shared font formatting for text measurement and drawing.
- Updated `IrText` to use the same bold-aware font path for initial draw and segmented font switches.
- Added focused regressions for bold and non-bold font usage during measurement and drawing.

## Validation
- `pnpm test src/__tests__/drawTextBold.test.ts`
- `pnpm lint`
- `pnpm test`
- `pnpm build`

## Review
- Deep-review self pass: no actionable findings.
- Independent subagent review: no actionable findings.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR threads the `bold` option through the shared font-formatting utilities so that both text measurement and drawing use the same bold-aware font string. Previously, `__updateFont` in `IrText` used a hardcoded non-bold font regardless of the `bold` option, causing a mismatch between measured and rendered text width.

- `parseFont` gains an optional `bold` parameter; for `defont` it swaps in `\"bold\"` directly, while for `gulim`/`simsun` a new `formatFontWeight` helper replaces the numeric weight token in the template string via regex.
- `measure()` in `flashText.ts` and all three font-setting sites in `IrText.__draw()` now forward `this.options.bold`, and the `bold` setter is updated to call `__updateFont()` so the canvas context font stays in sync immediately.
- Focused regression tests verify that both the `measureText` and `fillText` canvas calls receive a bold or non-bold font string depending on the flag.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; the change correctly aligns measurement and drawing to use the same bold font, with regression tests confirming the before/after behaviour.

The core logic is sound and well-tested. The only noteworthy point is that formatFontWeight silently passes through the unchanged font string when the regex does not match, which would mean bold is ignored for any future custom font template that uses a non-numeric, non-bold weight keyword. For the two built-in templates this is not a problem today.

src/utils/utils.ts — the formatFontWeight regex handles only the current built-in font template formats; worth revisiting if new font templates are added with different weight tokens.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/utils/utils.ts | Added formatFontWeight helper and updated parseFont to accept an optional bold parameter; regex approach works correctly for current config but would silently no-op on non-standard weight tokens |
| src/utils/flashText.ts | Added bold = false parameter to measure(), forwarding it to parseFont for each content item — backward-compatible and consistent with drawing |
| src/objects/text.ts | Bold flag now threaded through __updateFont, __measure, and __draw; bold setter correctly calls __updateFont() before marking modified, consistent with existing scale setter pattern |
| src/__tests__/drawTextBold.test.ts | New focused regression tests covering bold/non-bold font in parseFont and in IrText measurement/draw paths; canvas mock correctly tracks per-call font state |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["bold setter / __measure / __draw"] -->|"font, size, bold"| B["parseFont()"]
    B --> C{font type?}
    C -->|"gulim / simsun"| D["config.font[font].replace('[size]', size)"]
    D -->|"bold=true"| E["formatFontWeight()\nregex replaces numeric weight with bold"]
    D -->|"bold=false"| F["return original template string"]
    C -->|"defont (default)"| G{bold?}
    G -->|"true"| H["'bold Npx {defont.font}'"]
    G -->|"false"| I["'{defont.weight} Npx {defont.font}'"]
    E --> J["ctx.font = bold font string"]
    F --> J
    H --> J
    I --> J
    J --> K["measureText / fillText"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["bold setter / __measure / __draw"] -->|"font, size, bold"| B["parseFont()"]
    B --> C{font type?}
    C -->|"gulim / simsun"| D["config.font[font].replace('[size]', size)"]
    D -->|"bold=true"| E["formatFontWeight()\nregex replaces numeric weight with bold"]
    D -->|"bold=false"| F["return original template string"]
    C -->|"defont (default)"| G{bold?}
    G -->|"true"| H["'bold Npx {defont.font}'"]
    G -->|"false"| I["'{defont.weight} Npx {defont.font}'"]
    E --> J["ctx.font = bold font string"]
    F --> J
    H --> J
    I --> J
    J --> K["measureText / fillText"]
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Futils%2Futils.ts%3A25-28%0A**Regex%20silently%20no-ops%20for%20unrecognised%20weight%20tokens**%0A%0A%60formatFontWeight%60%20only%20matches%20%60%5Cd%2B%60%20%28e.g.%20%60600%60%29%20or%20the%20literal%20keyword%20%60bold%60.%20Any%20other%20CSS%20weight%20keyword%20%E2%80%94%20%60normal%60%2C%20%60bolder%60%2C%20%60lighter%60%20%E2%80%94%20in%20a%20customised%20font%20template%20will%20cause%20the%20regex%20to%20produce%20no%20match%2C%20and%20the%20original%20%28non-bold%29%20font%20string%20is%20returned%20unchanged%20without%20any%20error.%20For%20the%20two%20built-in%20font%20templates%20this%20isn't%20a%20problem%20today%2C%20but%20it%20means%20a%20future%20template%20like%20%60'normal%20normal%20%5Bsize%5Dpx%20...'%60%20would%20silently%20ignore%20the%20%60bold%60%20flag.%0A%0A&repo=xpadev-net%2Fniwango.js&pr=28&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/utils/utils.ts:25-28
**Regex silently no-ops for unrecognised weight tokens**

`formatFontWeight` only matches `\d+` (e.g. `600`) or the literal keyword `bold`. Any other CSS weight keyword — `normal`, `bolder`, `lighter` — in a customised font template will cause the regex to produce no match, and the original (non-bold) font string is returned unchanged without any error. For the two built-in font templates this isn't a problem today, but it means a future template like `'normal normal [size]px ...'` would silently ignore the `bold` flag.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Apply bold text weight to rendering"](https://github.com/xpadev-net/niwango.js/commit/05fa79a2064a9764d0272793880cd0a5ff001213) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39363145)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->