### PR TITLE
Validate CanvasRender target canvas size

### DIFF
--- a/docs/playground.html
+++ b/docs/playground.html
@@ -4,7 +4,7 @@
     <textarea id="ast" spellcheck="false" readonly></textarea>
   </div>
   <div class="item right">
-    <canvas id="render"></canvas>
+    <canvas id="render" width="1920" height="1080"></canvas>
     <div id="outputWrapper">
       <div><button id="clear">clear</button></div>
       <div id="output"></div>
@@ -87,7 +87,10 @@
   #render {
     border: solid 1px black;
     aspect-ratio: 16/9;
+    display: block;
+    height: auto;
     transform-origin: 0 0;
+    width: 100%;
   }
   textarea {
     height: 100%;

--- a/src/__tests__/canvasRender.test.ts
+++ b/src/__tests__/canvasRender.test.ts
@@ -1,0 +1,141 @@
+import { readFileSync } from "node:fs";
+
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { config, initConfig } from "@/definition/config";
+import { CanvasRender } from "@/render/canvas";
+
+type MockCanvasContext = {
+  clearRect: ReturnType<typeof vi.fn>;
+  drawImage: ReturnType<typeof vi.fn>;
+  restore: ReturnType<typeof vi.fn>;
+  rotate: ReturnType<typeof vi.fn>;
+  save: ReturnType<typeof vi.fn>;
+  scale: ReturnType<typeof vi.fn>;
+  translate: ReturnType<typeof vi.fn>;
+};
+
+const createMockContext = (): MockCanvasContext => ({
+  clearRect: vi.fn(),
+  drawImage: vi.fn(),
+  restore: vi.fn(),
+  rotate: vi.fn(),
+  save: vi.fn(),
+  scale: vi.fn(),
+  translate: vi.fn(),
+});
+
+describe("CanvasRender target canvas size", () => {
+  let contexts: MockCanvasContext[];
+
+  const getContextAt = (index: number) => {
+    const context = contexts[index];
+    if (!context) throw new Error(`missing mocked canvas context ${index}`);
+    return context;
+  };
+
+  beforeEach(() => {
+    initConfig();
+    contexts = [];
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockImplementation(
+      (() => {
+        const context = createMockContext();
+        contexts.push(context);
+        return context as unknown as CanvasRenderingContext2D;
+      }) as unknown as typeof HTMLCanvasElement.prototype.getContext,
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("initializes an unconfigured target canvas to the render size", () => {
+    const targetCanvas = document.createElement("canvas");
+
+    const render = new CanvasRender(targetCanvas);
+
+    expect(targetCanvas.width).toBe(1920);
+    expect(targetCanvas.height).toBe(1080);
+    expect(getContextAt(1).scale).toHaveBeenCalledWith(
+      1920 / config.canvasWidth,
+      1080 / config.canvasHeight,
+    );
+
+    render.apply(true);
+
+    expect(getContextAt(0).clearRect).toHaveBeenCalledWith(0, 0, 1920, 1080);
+    expect(getContextAt(0).drawImage).toHaveBeenCalledWith(
+      expect.any(HTMLCanvasElement),
+      0,
+      0,
+      1920,
+      1080,
+      0,
+      0,
+      1920,
+      1080,
+    );
+  });
+
+  test("preserves an explicitly configured 16:9 target canvas", () => {
+    const targetCanvas = document.createElement("canvas");
+    targetCanvas.width = 640;
+    targetCanvas.height = 360;
+
+    const render = new CanvasRender(targetCanvas);
+
+    expect(targetCanvas.width).toBe(640);
+    expect(targetCanvas.height).toBe(360);
+
+    render.apply(true);
+
+    expect(getContextAt(0).drawImage).toHaveBeenCalledWith(
+      expect.any(HTMLCanvasElement),
+      0,
+      0,
+      1920,
+      1080,
+      0,
+      0,
+      640,
+      360,
+    );
+  });
+
+  test("rejects an explicitly configured non-16:9 target canvas", () => {
+    const targetCanvas = document.createElement("canvas");
+    targetCanvas.setAttribute("width", "300");
+    targetCanvas.setAttribute("height", "150");
+
+    expect(() => new CanvasRender(targetCanvas)).toThrow(
+      "CanvasRender target canvas must use a 16:9 intrinsic size. Received 300x150.",
+    );
+    expect(contexts).toHaveLength(0);
+  });
+
+  test("rejects an empty target canvas", () => {
+    const targetCanvas = document.createElement("canvas");
+    targetCanvas.setAttribute("width", "0");
+    targetCanvas.setAttribute("height", "0");
+
+    expect(() => new CanvasRender(targetCanvas)).toThrow(
+      "CanvasRender target canvas must use a 16:9 intrinsic size. Received 0x0.",
+    );
+    expect(contexts).toHaveLength(0);
+  });
+
+  test("configures the playground canvas with 16:9 intrinsic dimensions", () => {
+    const playground = readFileSync("docs/playground.html", "utf8");
+    const document = new DOMParser().parseFromString(playground, "text/html");
+    const canvas = document.querySelector("#render");
+    if (!canvas) throw new Error("missing playground render canvas");
+
+    const width = Number(canvas.getAttribute("width"));
+    const height = Number(canvas.getAttribute("height"));
+
+    expect(width).toBe(1920);
+    expect(height).toBe(1080);
+    expect(width * 9).toBe(height * 16);
+  });
+});

--- a/src/__tests__/canvasRender.test.ts
+++ b/src/__tests__/canvasRender.test.ts
@@ -27,22 +27,31 @@ const createMockContext = (): MockCanvasContext => ({
 
 describe("CanvasRender target canvas size", () => {
   let contexts: MockCanvasContext[];
+  let canvasContexts: Array<[HTMLCanvasElement, MockCanvasContext]>;
 
-  const getContextAt = (index: number) => {
-    const context = contexts[index];
-    if (!context) throw new Error(`missing mocked canvas context ${index}`);
+  const getContextFor = (canvas: HTMLCanvasElement) => {
+    const context = canvasContexts.find(([element]) => element === canvas)?.[1];
+    if (!context) throw new Error("missing mocked canvas context");
+    return context;
+  };
+
+  const getOtherContext = (canvas: HTMLCanvasElement) => {
+    const context = canvasContexts.find(([element]) => element !== canvas)?.[1];
+    if (!context) throw new Error("missing second mocked canvas context");
     return context;
   };
 
   beforeEach(() => {
     initConfig();
     contexts = [];
+    canvasContexts = [];
     vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockImplementation(
-      (() => {
+      function (this: HTMLCanvasElement) {
         const context = createMockContext();
         contexts.push(context);
+        canvasContexts.push([this, context]);
         return context as unknown as CanvasRenderingContext2D;
-      }) as unknown as typeof HTMLCanvasElement.prototype.getContext,
+      } as unknown as typeof HTMLCanvasElement.prototype.getContext,
     );
   });
 
@@ -57,15 +66,20 @@ describe("CanvasRender target canvas size", () => {
 
     expect(targetCanvas.width).toBe(1920);
     expect(targetCanvas.height).toBe(1080);
-    expect(getContextAt(1).scale).toHaveBeenCalledWith(
+    expect(getOtherContext(targetCanvas).scale).toHaveBeenCalledWith(
       1920 / config.canvasWidth,
       1080 / config.canvasHeight,
     );
 
     render.apply(true);
 
-    expect(getContextAt(0).clearRect).toHaveBeenCalledWith(0, 0, 1920, 1080);
-    expect(getContextAt(0).drawImage).toHaveBeenCalledWith(
+    expect(getContextFor(targetCanvas).clearRect).toHaveBeenCalledWith(
+      0,
+      0,
+      1920,
+      1080,
+    );
+    expect(getContextFor(targetCanvas).drawImage).toHaveBeenCalledWith(
       expect.any(HTMLCanvasElement),
       0,
       0,
@@ -90,7 +104,7 @@ describe("CanvasRender target canvas size", () => {
 
     render.apply(true);
 
-    expect(getContextAt(0).drawImage).toHaveBeenCalledWith(
+    expect(getContextFor(targetCanvas).drawImage).toHaveBeenCalledWith(
       expect.any(HTMLCanvasElement),
       0,
       0,

--- a/src/render/canvas.ts
+++ b/src/render/canvas.ts
@@ -8,6 +8,35 @@ const isDrawOptionA = (i: DrawOptions): i is DrawOptionA =>
   (i as DrawOptionA).baseX !== undefined;
 
 const TO_RADIANS = Math.PI / 180;
+const RENDER_CANVAS_WIDTH = 1920;
+const RENDER_CANVAS_HEIGHT = 1080;
+const DEFAULT_CANVAS_WIDTH = 300;
+const DEFAULT_CANVAS_HEIGHT = 150;
+
+const hasDefaultIntrinsicSize = (canvas: HTMLCanvasElement) =>
+  !canvas.hasAttribute("width") &&
+  !canvas.hasAttribute("height") &&
+  canvas.width === DEFAULT_CANVAS_WIDTH &&
+  canvas.height === DEFAULT_CANVAS_HEIGHT;
+
+const hasRenderAspectRatio = (canvas: HTMLCanvasElement) =>
+  canvas.width > 0 &&
+  canvas.height > 0 &&
+  canvas.width * RENDER_CANVAS_HEIGHT === canvas.height * RENDER_CANVAS_WIDTH;
+
+const initializeTargetCanvasSize = (canvas: HTMLCanvasElement) => {
+  if (hasDefaultIntrinsicSize(canvas)) {
+    canvas.width = RENDER_CANVAS_WIDTH;
+    canvas.height = RENDER_CANVAS_HEIGHT;
+    return;
+  }
+
+  if (!hasRenderAspectRatio(canvas)) {
+    throw new Error(
+      `CanvasRender target canvas must use a 16:9 intrinsic size. Received ${canvas.width}x${canvas.height}.`,
+    );
+  }
+};
 
 class CanvasRender implements IRender {
   private readonly targetCanvas: HTMLCanvasElement;
@@ -16,9 +45,10 @@ class CanvasRender implements IRender {
   private readonly renderContext: CanvasRenderingContext2D;
   constructor(targetCanvas: HTMLCanvasElement) {
     this.targetCanvas = targetCanvas;
+    initializeTargetCanvasSize(this.targetCanvas);
     this.renderCanvas = document.createElement("canvas");
-    this.renderCanvas.width = 1920;
-    this.renderCanvas.height = 1080;
+    this.renderCanvas.width = RENDER_CANVAS_WIDTH;
+    this.renderCanvas.height = RENDER_CANVAS_HEIGHT;
     const targetContext = this.targetCanvas.getContext("2d");
     const renderContext = this.renderCanvas.getContext("2d");
     if (!targetContext || !renderContext)
@@ -26,8 +56,8 @@ class CanvasRender implements IRender {
     this.targetContext = targetContext;
     this.renderContext = renderContext;
     this.renderContext.scale(
-      1920 / config.canvasWidth,
-      1080 / config.canvasHeight,
+      RENDER_CANVAS_WIDTH / config.canvasWidth,
+      RENDER_CANVAS_HEIGHT / config.canvasHeight,
     );
   }
 


### PR DESCRIPTION
## Summary
- Initialize unconfigured CanvasRender targets to 1920x1080 intrinsic dimensions
- Validate explicitly configured target canvases are positive 16:9 sizes
- Set playground canvas attributes/CSS for intended 16:9 rendering
- Add focused regression coverage for canvas sizing and playground markup

## Validation
- pnpm test
- pnpm lint
- pnpm build

## Review
- deep-review self pass: no remaining actionable findings after fixing 0x0 validation edge case
- independent subagent review: no actionable findings

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds canvas size validation and default initialization to `CanvasRender`, ensuring every render target has a positive 16:9 intrinsic size, and adds regression tests and playground markup to match.

- `src/render/canvas.ts`: Adds `initializeTargetCanvasSize`, which auto-initializes a freshly-created (attribute-less, 300×150) canvas to 1920×1080 and rejects explicitly configured canvases that are not 16:9 — magic numbers replaced with named constants throughout.
- `src/__tests__/canvasRender.test.ts`: New test file covering unconfigured, valid 16:9, non-16:9, 0x0, and playground HTML cases; uses identity-based context tracking that survives constructor reordering.
- `docs/playground.html`: Adds `width=\"1920\" height=\"1080\"` to the canvas element and responsive CSS (`display: block; width: 100%; height: auto`) so the canvas fills its container at 16:9.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the validation logic is correct, tests are thorough, and the changes are well-scoped to canvas initialization.

The detection heuristic in `hasDefaultIntrinsicSize` is sound and covers all realistic inputs. The one asymmetry (JS-property assignment of exactly 300×150 vs setAttribute) affects only the browser's own default canvas dimensions, which are never a valid 16:9 render target in this context, so no real user path is broken. All three files are clean.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/render/canvas.ts | Adds canvas size validation and default 1920x1080 initialization; logic is sound, with a minor asymmetry in default-size detection when dimensions are set via JS property vs HTML attribute |
| src/__tests__/canvasRender.test.ts | New focused test suite; uses identity-based context lookup addressing the fragile index-based concern; covers unconfigured, valid 16:9, non-16:9, 0x0, and playground HTML cases |
| docs/playground.html | Adds explicit 1920x1080 intrinsic dimensions to the canvas element and responsive CSS to make it fill its container at 16:9 |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["new CanvasRender(targetCanvas)"] --> B["initializeTargetCanvasSize"]
    B --> C{"hasDefaultIntrinsicSize?"}
    C -- "no attrs + 300x150" --> D["Set canvas to 1920x1080"]
    D --> E["Create renderCanvas 1920x1080"]
    C -- "has attrs or different size" --> F{"hasRenderAspectRatio?"}
    F -- "width*1080 = height*1920 AND both positive" --> E
    F -- "fails" --> G["throw Error: must be 16:9"]
    E --> H["getContext for both canvases"]
    H --> I["renderContext.scale to config dims"]
    I --> J["CanvasRender ready"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["new CanvasRender(targetCanvas)"] --> B["initializeTargetCanvasSize"]
    B --> C{"hasDefaultIntrinsicSize?"}
    C -- "no attrs + 300x150" --> D["Set canvas to 1920x1080"]
    D --> E["Create renderCanvas 1920x1080"]
    C -- "has attrs or different size" --> F{"hasRenderAspectRatio?"}
    F -- "width*1080 = height*1920 AND both positive" --> E
    F -- "fails" --> G["throw Error: must be 16:9"]
    E --> H["getContext for both canvases"]
    H --> I["renderContext.scale to config dims"]
    I --> J["CanvasRender ready"]
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mas..."](https://github.com/xpadev-net/niwango.js/commit/c4553ba3c47d27f318451c292cad75ada992952c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39363583)</sub>

<!-- /greptile_comment -->