### PR TITLE
ci: publish dev build without force push

### DIFF
--- a/.github/workflows/create-dev-build.yml
+++ b/.github/workflows/create-dev-build.yml
@@ -5,15 +5,21 @@ on:
     branches: [ master ]
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 22.x
           registry-url: 'https://registry.npmjs.org'
@@ -33,13 +39,49 @@ jobs:
         run: pnpm typedoc
       - name: update .gitignore
         run: sed -i -e '/\/docs\/type/d' .gitignore
-      - name: Create new Branch
+      - name: Publish dev build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          TARGET_BRANCH: dev-build
         run: |
+          set -euo pipefail
+
+          if [ "${GITHUB_REF_NAME}" != "${DEFAULT_BRANCH}" ]; then
+            echo "Refusing to publish ${TARGET_BRANCH} from non-default branch ${GITHUB_REF_NAME}."
+            exit 1
+          fi
+
+          if [ "${TARGET_BRANCH}" = "${DEFAULT_BRANCH}" ]; then
+            echo "Refusing to publish dev build to default branch ${DEFAULT_BRANCH}."
+            exit 1
+          fi
+
+          open_pr_count="$(gh pr list --repo "${GITHUB_REPOSITORY}" --head "${TARGET_BRANCH}" --state open --json number --jq 'length')"
+          if [ "${open_pr_count}" != "0" ]; then
+            echo "Refusing to publish ${TARGET_BRANCH} while it has an open pull request."
+            exit 1
+          fi
+
           git config user.email "github-actions@xpadev.net"
           git config user.name "github-actions"
-          git checkout -b dev-build
+
           git add .
+          generated_tree="$(git write-tree)"
+          git reset --hard "${GITHUB_SHA}"
+
+          if git ls-remote --exit-code --heads origin "${TARGET_BRANCH}" >/dev/null; then
+            git fetch origin "refs/heads/${TARGET_BRANCH}:refs/remotes/origin/${TARGET_BRANCH}"
+            git switch -C "${TARGET_BRANCH}" "origin/${TARGET_BRANCH}"
+          else
+            git switch -C "${TARGET_BRANCH}" "${GITHUB_SHA}"
+          fi
+
+          git read-tree --reset -u "${generated_tree}"
+          if git diff --cached --quiet; then
+            echo "No dev build changes to publish."
+            exit 0
+          fi
+
           git commit -m "auto generate" -n
-          git push -f origin dev-build
+          git push origin "HEAD:${TARGET_BRANCH}"

--- a/.github/workflows/create-dev-build.yml
+++ b/.github/workflows/create-dev-build.yml
@@ -5,13 +5,16 @@ on:
     branches: [ master ]
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: read
+concurrency:
+  group: dev-build-publish
+  cancel-in-progress: false
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- replace the dev-build workflow force push with a normal commit on top of the existing dev-build branch
- refuse publishing from non-default refs, to the default branch, or while dev-build has an open PR
- update checkout/setup-node actions so actionlint passes on current runners

## Validation
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/create-dev-build.yml"); puts "YAML OK"'
- go run github.com/rhysd/actionlint/cmd/actionlint@latest -color .github/workflows/create-dev-build.yml
- pnpm lint
- pre-commit hook: check-types and test

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR refactors the dev-build CI workflow to append a normal commit to the `dev-build` branch instead of force-pushing, preserving branch history and allowing open PRs against it to survive multiple master pushes safely.

- Three safety guards are introduced: refusing to run from a non-default branch, refusing if `TARGET_BRANCH` equals the default branch, and refusing while an open PR targets `dev-build`. A concurrency group (`cancel-in-progress: false`) serialises concurrent workflow runs so queued jobs never race each other on the push.
- The git strategy captures the full generated tree with `git write-tree`, resets to master, switches to (or creates) `dev-build`, then uses `git read-tree --reset -u` to restore the generated state — a clean way to graft generated content onto a different branch's history without dirtying the working tree.
- `actions/checkout` and `actions/setup-node` are updated from v3 to v4.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a net improvement in correctness and safety over the existing force-push approach.

The workflow logic is sound: the three guard conditions are mutually exclusive and correctly ordered, the concurrency lock serialises concurrent runs, and the git write-tree / read-tree technique correctly grafts generated content onto dev-build history without dirtying the working tree. Action version bumps are straightforward. No changed behaviour that could corrupt state or produce incorrect output was found.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/create-dev-build.yml | Replaces force-push with an appending-commit strategy for the dev-build branch, adds three safety guards, a concurrency lock, and bumps checkout/setup-node to v4. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([Trigger]) --> B[Checkout with full history]
    B --> C[Build and generate artifacts]
    C --> D[Stage files and capture tree SHA]
    D --> E[Reset to GITHUB_SHA]
    E --> G{From default branch?}
    G -- No --> H[Fail - refuse non-default ref]
    G -- Yes --> I{Target equals default branch?}
    I -- Yes --> J[Fail - refuse writing to default]
    I -- No --> K{Open PRs on dev-build?}
    K -- Yes --> L[Fail - refuse while PR open]
    K -- No --> M{dev-build exists on origin?}
    M -- Yes --> N[Switch to existing dev-build]
    M -- No --> O[Create dev-build from master SHA]
    N --> P[Apply generated tree to index]
    O --> P
    P --> Q{Any changes?}
    Q -- No --> R[Exit 0 - nothing to publish]
    Q -- Yes --> S[Commit and push to dev-build]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A([Trigger]) --> B[Checkout with full history]
    B --> C[Build and generate artifacts]
    C --> D[Stage files and capture tree SHA]
    D --> E[Reset to GITHUB_SHA]
    E --> G{From default branch?}
    G -- No --> H[Fail - refuse non-default ref]
    G -- Yes --> I{Target equals default branch?}
    I -- Yes --> J[Fail - refuse writing to default]
    I -- No --> K{Open PRs on dev-build?}
    K -- Yes --> L[Fail - refuse while PR open]
    K -- No --> M{dev-build exists on origin?}
    M -- Yes --> N[Switch to existing dev-build]
    M -- No --> O[Create dev-build from master SHA]
    N --> P[Apply generated tree to index]
    O --> P
    P --> Q{Any changes?}
    Q -- No --> R[Exit 0 - nothing to publish]
    Q -- Yes --> S[Commit and push to dev-build]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["ci: tighten dev build publish permission..."](https://github.com/xpadev-net/niwango.js/commit/7dbc02d53b6f3a82f5aa1f873a484e5361208cad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39363890)</sub>

<!-- /greptile_comment -->