### PR TITLE
Fix package entrypoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,10 +10,12 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
+      "browser": "./dist/browser/niwango.js",
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs",
       "default": "./dist/index.mjs"
     },
+    "./browser": "./dist/browser/niwango.js",
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -2,9 +2,20 @@
   "name": "@xpadev-net/niwango",
   "version": "0.0.1-canary.20231002-1",
   "description": "parse and execute niwango",
-  "main": "dist/bundle.js",
-  "types": "dist/bundle.d.ts",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "browser": "./dist/browser/niwango.js",
   "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs",
+      "default": "./dist/index.mjs"
+    },
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "build": "npx rimraf dist&&npm run build:ts&&npm run build:dts",
     "build:ts": "rolldown -c rolldown.config.mjs",
@@ -19,11 +30,14 @@
     "lint": "biome check src && pnpm check-types",
     "lint:fix": "biome check --write src && pnpm check-types",
     "prepare": "lefthook install",
+    "smoke:package": "node tests/smoke/package-entrypoints.mjs",
     "test": "vitest run"
   },
   "files": [
-    "dist/bundle.js",
-    "dist/bundle.d.ts"
+    "dist/index.mjs",
+    "dist/index.cjs",
+    "dist/index.d.ts",
+    "dist/browser/niwango.js"
   ],
   "author": "xpadev(xpadev.net)",
   "license": "MIT",

--- a/rolldown.config.dts.mjs
+++ b/rolldown.config.dts.mjs
@@ -5,7 +5,7 @@ export default defineConfig({
   input: './dist/dts/main.d.ts',
   plugins: [dts()],
   output: {
-    file: 'dist/bundle.d.ts',
+    file: 'dist/index.d.ts',
     format: 'es',
   },
 });

--- a/rolldown.config.mjs
+++ b/rolldown.config.mjs
@@ -14,12 +14,26 @@ const banner = `/*!
 
 export default defineConfig({
   input: 'src/main.ts',
-  output: {
-    file: 'dist/bundle.js',
-    format: 'umd',
-    name: 'Niwango',
-    banner,
-  },
+  output: [
+    {
+      file: 'dist/index.mjs',
+      format: 'es',
+      banner,
+    },
+    {
+      file: 'dist/index.cjs',
+      format: 'cjs',
+      exports: 'default',
+      banner,
+    },
+    {
+      file: 'dist/browser/niwango.js',
+      format: 'umd',
+      name: 'Niwango',
+      exports: 'default',
+      banner,
+    },
+  ],
   resolve: {
     alias: {
       '@': './src',

--- a/tests/smoke/package-entrypoints.mjs
+++ b/tests/smoke/package-entrypoints.mjs
@@ -26,13 +26,14 @@ mkdirSync(consumerDirectory, { recursive: true });
 
 const packOutput = execFileSync(
   "npm",
-  ["pack", "--ignore-scripts", "--pack-destination", packDirectory],
+  ["pack", "--json", "--ignore-scripts", "--pack-destination", packDirectory],
   {
     cwd: repoRoot,
     encoding: "utf8",
   },
 ).trim();
-const tarball = join(packDirectory, packOutput.split("\n").at(-1));
+const [{ filename: tarballFilename }] = JSON.parse(packOutput);
+const tarball = join(packDirectory, tarballFilename);
 
 writeFileSync(
   join(consumerDirectory, "package.json"),

--- a/tests/smoke/package-entrypoints.mjs
+++ b/tests/smoke/package-entrypoints.mjs
@@ -1,0 +1,121 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const workspace = mkdtempSync(join(tmpdir(), "niwango-package-smoke-"));
+const packDirectory = join(workspace, "pack");
+const consumerDirectory = join(workspace, "consumer");
+
+process.on("exit", () => {
+  rmSync(workspace, { recursive: true, force: true });
+});
+
+const run = (command, args, options = {}) => {
+  execFileSync(command, args, {
+    cwd: repoRoot,
+    stdio: "inherit",
+    ...options,
+  });
+};
+
+mkdirSync(packDirectory, { recursive: true });
+mkdirSync(consumerDirectory, { recursive: true });
+
+const packOutput = execFileSync(
+  "npm",
+  ["pack", "--ignore-scripts", "--pack-destination", packDirectory],
+  {
+    cwd: repoRoot,
+    encoding: "utf8",
+  },
+).trim();
+const tarball = join(packDirectory, packOutput.split("\n").at(-1));
+
+writeFileSync(
+  join(consumerDirectory, "package.json"),
+  JSON.stringify({ private: true, type: "module" }, null, 2),
+);
+
+run(
+  "npm",
+  [
+    "install",
+    "--ignore-scripts",
+    "--no-audit",
+    "--no-fund",
+    "--package-lock=false",
+    tarball,
+  ],
+  { cwd: consumerDirectory },
+);
+
+writeFileSync(
+  join(consumerDirectory, "esm.mjs"),
+  [
+    'import Niwango from "@xpadev-net/niwango";',
+    'if (typeof Niwango !== "function") {',
+    '  throw new Error("ESM import did not resolve the Niwango constructor");',
+    "}",
+    "if (Niwango.default !== Niwango) {",
+    '  throw new Error("ESM import lost the constructor default alias");',
+    "}",
+  ].join("\n"),
+);
+
+writeFileSync(
+  join(consumerDirectory, "cjs.cjs"),
+  [
+    'const Niwango = require("@xpadev-net/niwango");',
+    'if (typeof Niwango !== "function") {',
+    '  throw new Error("CJS require did not resolve the Niwango constructor");',
+    "}",
+    "if (Niwango.default !== Niwango) {",
+    '  throw new Error("CJS require lost the constructor default alias");',
+    "}",
+  ].join("\n"),
+);
+
+writeFileSync(
+  join(consumerDirectory, "types.ts"),
+  [
+    'import Niwango from "@xpadev-net/niwango";',
+    "",
+    "const Ctor: typeof Niwango = Niwango;",
+    'const element = document.createElement("div");',
+    "const player = new Ctor(element, []);",
+    "const didDraw: boolean = player.draw(0);",
+    "void didDraw;",
+  ].join("\n"),
+);
+
+writeFileSync(
+  join(consumerDirectory, "tsconfig.json"),
+  JSON.stringify(
+    {
+      compilerOptions: {
+        strict: true,
+        target: "ES2022",
+        module: "NodeNext",
+        moduleResolution: "NodeNext",
+        lib: ["ES2022", "DOM"],
+        noEmit: true,
+      },
+      include: ["types.ts"],
+    },
+    null,
+    2,
+  ),
+);
+
+run("node", ["esm.mjs"], { cwd: consumerDirectory });
+run("node", ["cjs.cjs"], { cwd: consumerDirectory });
+
+const tscCommand = process.platform === "win32" ? "tsc.cmd" : "tsc";
+run(
+  join(repoRoot, "node_modules", ".bin", tscCommand),
+  ["--project", "tsconfig.json"],
+  { cwd: consumerDirectory },
+);


### PR DESCRIPTION
## Summary
- publish separate Node ESM and CJS artifacts at dist/index.mjs and dist/index.cjs
- keep the UMD browser bundle at dist/browser/niwango.js
- add package exports/types metadata and a packed-package smoke test for import, require, and TypeScript resolution

## Validation
- pnpm test
- pnpm lint
- pnpm build
- npm pack --dry-run --ignore-scripts
- pnpm smoke:package

## Review
- deep-review self-review completed
- independent subagent review completed with no actionable findings

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR replaces the single `dist/bundle.js` UMD-only artifact with three separate build outputs — `dist/index.mjs` (ESM), `dist/index.cjs` (CJS), and `dist/browser/niwango.js` (UMD) — and wires them up through a proper `exports` map and updated `files` list. A new end-to-end smoke test validates ESM import, CJS require, and TypeScript type resolution against the packed artifact before publish.

- **Build config** (`rolldown.config.mjs`): output array now targets ES, CJS, and UMD formats with `exports: 'default'` on CJS/UMD, consistent with the `static default = Niwango` alias in `src/main.ts` that the smoke test validates.
- **Package metadata** (`package.json`): `main`, `module`, `types`, and the `exports` map are all updated; a `./browser` subpath and `./package.json` subpath are exposed alongside the primary `.` export.
- **Smoke test** (`tests/smoke/package-entrypoints.mjs`): packs the package with `npm pack --json`, installs into an isolated temp directory, then runs three probes — a Node ESM script, a CJS script, and `tsc` with `moduleResolution: NodeNext` — to confirm each entrypoint resolves correctly.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge; all three build artifacts and the exports map are internally consistent, the smoke test validates real consumer behavior, and no cross-repo consumers of @xpadev-net/niwango were found in the related repositories.

The change is a well-scoped entrypoint restructure backed by an end-to-end smoke test that packs and installs the real artifact. The only open item is the bare-string ./browser subpath export having no TypeScript types, which affects only consumers who explicitly import from that subpath (a niche use case since the UMD bundle is primarily for script-tag use). No cross-repo breakage was found.

package.json — the ./browser subpath export could benefit from a types condition for TypeScript consumers who explicitly target that subpath.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | Replaces single UMD entrypoint with three artifacts (ESM, CJS, UMD) plus a proper exports map; the ./browser subpath is a bare string with no types condition and no corresponding .d.ts in the published files. |
| rolldown.config.mjs | Expands single UMD output to three separate outputs (ESM, CJS, UMD); exports: 'default' on CJS and UMD matches the static default alias in src/main.ts and the smoke test expectations. |
| rolldown.config.dts.mjs | Renames DTS output from dist/bundle.d.ts to dist/index.d.ts to match the new entrypoint naming convention; straightforward rename. |
| tests/smoke/package-entrypoints.mjs | New smoke test that packs the package, installs into a temp consumer, and validates ESM import, CJS require, and TypeScript type resolution against the published artifacts. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["import '@xpadev-net/niwango'"] --> B{exports map condition check}
    B -->|TypeScript| C["types: dist/index.d.ts"]
    B -->|Browser bundler Vite/Webpack5| D["browser: dist/browser/niwango.js (UMD)"]
    B -->|ESM import| E["import: dist/index.mjs (ES module)"]
    B -->|CJS require| F["require: dist/index.cjs (CommonJS)"]
    B -->|fallback| G["default: dist/index.mjs"]
    H["import '@xpadev-net/niwango/browser'"] --> I["./browser: dist/browser/niwango.js (string shorthand — no types condition)"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["import '@xpadev-net/niwango'"] --> B{exports map condition check}
    B -->|TypeScript| C["types: dist/index.d.ts"]
    B -->|Browser bundler Vite/Webpack5| D["browser: dist/browser/niwango.js (UMD)"]
    B -->|ESM import| E["import: dist/index.mjs (ES module)"]
    B -->|CJS require| F["require: dist/index.cjs (CommonJS)"]
    B -->|fallback| G["default: dist/index.mjs"]
    H["import '@xpadev-net/niwango/browser'"] --> I["./browser: dist/browser/niwango.js (string shorthand — no types condition)"]
```

</a>
</details>

<sub>Reviews (4): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mas..."](https://github.com/xpadev-net/niwango.js/commit/b9cea4e9778b425295ad02daebdd96e1e3567e42) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39364727)</sub>

<!-- /greptile_comment -->