### PR TITLE
Guard result hook literal inputs

### DIFF
--- a/src/__tests__/resultHook.test.ts
+++ b/src/__tests__/resultHook.test.ts
@@ -1,8 +1,39 @@
-import { describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
+import { resetCanvas } from "@/contexts/canvas";
+import { resetObjects } from "@/contexts/objectManager";
 import { resultHook } from "@/contexts/snapshot";
+import { initConfig } from "@/definition/config";
+import { IrText } from "@/objects/text";
+
+const createMockContext = () => ({
+  clearRect: vi.fn(),
+  drawImage: vi.fn(),
+  fillRect: vi.fn(),
+  fillText: vi.fn(),
+  measureText: vi.fn((text: string) => ({
+    actualBoundingBoxAscent: 10,
+    actualBoundingBoxDescent: 2,
+    width: text.length * 10,
+  })),
+  restore: vi.fn(),
+  save: vi.fn(),
+  scale: vi.fn(),
+  strokeRect: vi.fn(),
+  strokeText: vi.fn(),
+});
 
 describe("resultHook", () => {
+  beforeEach(() => {
+    initConfig();
+    resetCanvas();
+    resetObjects();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   test.each([
     { __NIWANGO_LITERAL: "IrObject", __type: "IrText" },
     { __NIWANGO_LITERAL: "IrObject", __type: "IrText", options: {} },
@@ -10,5 +41,36 @@ describe("resultHook", () => {
   ])("returns malformed IrObject literal %# unchanged", (input) => {
     expect(() => resultHook(input)).not.toThrow();
     expect(resultHook(input)).toBe(input);
+  });
+
+  test("restores a valid IrText literal", () => {
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(
+      createMockContext() as unknown as CanvasRenderingContext2D,
+    );
+
+    const result = resultHook({
+      __NIWANGO_LITERAL: "IrObject",
+      __type: "IrText",
+      options: {
+        __id: "valid-text",
+        alpha: 0,
+        bold: false,
+        color: 0xffffff,
+        filter: "",
+        mover: "",
+        pos: "naka",
+        posX: "naka",
+        posY: "naka",
+        scale: 1,
+        size: 14,
+        text: "hello",
+        visible: true,
+        x: 0,
+        y: 0,
+        z: 0,
+      },
+    });
+
+    expect(result).toBeInstanceOf(IrText);
   });
 });

--- a/src/__tests__/resultHook.test.ts
+++ b/src/__tests__/resultHook.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "vitest";
+
+import { resultHook } from "@/contexts/snapshot";
+
+describe("resultHook", () => {
+  test.each([
+    { __NIWANGO_LITERAL: "IrObject", __type: "IrText" },
+    { __NIWANGO_LITERAL: "IrObject", __type: "IrText", options: {} },
+    { __NIWANGO_LITERAL: "IrObject", __type: "IrShape", options: null },
+  ])("returns malformed IrObject literal %# unchanged", (input) => {
+    expect(() => resultHook(input)).not.toThrow();
+    expect(resultHook(input)).toBe(input);
+  });
+});

--- a/src/contexts/snapshot.ts
+++ b/src/contexts/snapshot.ts
@@ -91,5 +91,6 @@ export {
   initResultHook,
   resetSnapshot,
   restoreSnapshot,
+  resultHook,
   saveSnapshot,
 };

--- a/src/typeGuard.ts
+++ b/src/typeGuard.ts
@@ -3,6 +3,53 @@ import type { IShapeLiteral } from "@/@types/IrShape";
 import type { ITextLiteral } from "@/@types/IrText";
 import { IrObject } from "@/objects/object";
 
+type PrimitiveTypeName = "boolean" | "number" | "string";
+type RecordValue = Record<string, unknown>;
+
+const textOptionTypes = {
+  text: "string",
+  x: "number",
+  y: "number",
+  z: "number",
+  size: "number",
+  pos: "string",
+  posX: "string",
+  posY: "string",
+  color: "number",
+  bold: "boolean",
+  visible: "boolean",
+  scale: "number",
+  filter: "string",
+  alpha: "number",
+  mover: "string",
+} satisfies Record<
+  Exclude<keyof ITextLiteral["options"], "__id">,
+  PrimitiveTypeName
+>;
+
+const shapeOptionTypes = {
+  x: "number",
+  y: "number",
+  z: "number",
+  shape: "string",
+  width: "number",
+  height: "number",
+  pos: "string",
+  posX: "string",
+  posY: "string",
+  color: "number",
+  visible: "boolean",
+  mask: "boolean",
+  commentmask: "boolean",
+  scale: "number",
+  alpha: "number",
+  rotation: "number",
+  mover: "string",
+} satisfies Record<
+  Exclude<keyof IShapeLiteral["options"], "__id">,
+  PrimitiveTypeName
+>;
+
 const typeGuard = {
   comment: (i: unknown): i is Comment =>
     objectVerify(i, [
@@ -19,17 +66,50 @@ const typeGuard = {
       "_owner",
     ]),
   IrTextLiteral: (i: unknown): i is ITextLiteral =>
-    typeof i === "object" &&
-    !!i &&
-    (i as ITextLiteral).__NIWANGO_LITERAL === "IrObject" &&
-    (i as ITextLiteral).__type === "IrText" &&
-    !(i instanceof IrObject),
+    isLiteralObject(i, "IrText") && objectHasTypes(i.options, textOptionTypes),
   IrShapeLiteral: (i: unknown): i is IShapeLiteral =>
-    typeof i === "object" &&
-    !!i &&
-    (i as IShapeLiteral).__NIWANGO_LITERAL === "IrObject" &&
-    (i as IShapeLiteral).__type === "IrShape" &&
-    !(i instanceof IrObject),
+    isLiteralObject(i, "IrShape") &&
+    objectHasTypes(i.options, shapeOptionTypes),
+};
+
+const isRecord = (item: unknown): item is RecordValue =>
+  typeof item === "object" && item !== null && !Array.isArray(item);
+
+const isLiteralObject = (
+  item: unknown,
+  type: IShapeLiteral["__type"] | ITextLiteral["__type"],
+): item is RecordValue & {
+  __NIWANGO_LITERAL: "IrObject";
+  __type: typeof type;
+  options: unknown;
+} =>
+  isRecord(item) &&
+  item.__NIWANGO_LITERAL === "IrObject" &&
+  item.__type === type &&
+  !(item instanceof IrObject);
+
+const objectHasTypes = (
+  item: unknown,
+  properties: Record<string, PrimitiveTypeName>,
+): item is RecordValue => {
+  if (!isRecord(item)) {
+    return false;
+  }
+  for (const [key, type] of Object.entries(properties)) {
+    if (
+      !Object.prototype.hasOwnProperty.call(item, key) ||
+      typeof item[key] !== type
+    ) {
+      return false;
+    }
+  }
+  if (
+    Object.prototype.hasOwnProperty.call(item, "__id") &&
+    typeof item.__id !== "string"
+  ) {
+    return false;
+  }
+  return true;
 };
 
 const objectVerify = (item: unknown, keys: string[]): boolean => {


### PR DESCRIPTION
## チケットへのリンク

* P1 resultHook の unknown 入力を安全に扱う

## やったこと

* IrText/IrShape literal guardsで `options` と必須オプションの実行時型を検証するようにしました。
* 不正な unknown literal は resultHook で復元処理に入らず、そのまま返るようにしました。
* `__NIWANGO_LITERAL: "IrObject", __type: "IrText"` でクラッシュしない回帰テストを追加しました。

## やらないこと

* unrelated snapshot mover behavior / timer / draw(vpos) / commentTrigger / drawShape / bold rendering / CanvasRender は変更しません。

## できるようになること（ユーザ目線）

* Core result hook に壊れた literal 形状の値が渡っても、プレイヤー側で例外になりにくくなります。

## できなくなること（ユーザ目線）

* 無し

## 動作確認

* `pnpm test` - passed
* `pnpm lint` - passed
* `pnpm build` - passed
* independent review subagent - no actionable findings

## その他

* malformed objects are returned unchanged per existing hook fallback contract.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR hardens the `resultHook` literal type guards in `typeGuard.ts` so that malformed `IrObject` literals (missing `options`, `options: null`, `options: {}`) are rejected before reaching `new IrText()` / `new IrShape()`, preventing the crashes that the old guards allowed through. It also exports `resultHook` from `snapshot.ts` to enable direct unit testing.

- **`src/typeGuard.ts`**: Replaces the previous shallow guards with new `isLiteralObject` + `objectHasTypes` helpers that validate every required primitive field in `options`; a `satisfies` constraint keeps option-type maps exhaustive against the actual TypeScript interfaces at compile time.
- **`src/contexts/snapshot.ts`**: `resultHook` is added to the module's named exports so it can be imported in tests.
- **`src/__tests__/resultHook.test.ts`**: Adds three negative regression cases plus one positive round-trip test (valid literal → `instanceof IrText`).
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — additive guards that reject malformed inputs and return them unchanged, with no alterations to snapshot, draw, or timer logic.

The new helpers correctly handle every malformed case: objectHasTypes receives undefined when options is absent and short-circuits via isRecord. The satisfies constraint guarantees compile-time exhaustiveness. The positive IrText round-trip test closes the regression gap flagged previously, and no related-repo consumers were found.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/typeGuard.ts | Adds isLiteralObject and objectHasTypes helpers to fully validate IrText/IrShape literal options before accepting them; satisfies constraints ensure field coverage stays in sync with the TypeScript interfaces at compile time. |
| src/contexts/snapshot.ts | Minimal change — exports resultHook so it can be unit-tested directly; no logic was changed. |
| src/__tests__/resultHook.test.ts | New test file covering three malformed-input regression cases and one valid IrText round-trip, addressing the gap flagged in the previous review. |

</details>

</details>

<sub>Reviews (3): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mas..."](https://github.com/xpadev-net/niwango.js/commit/05aea4e523e683391c560f9ed68d162a5099a4a0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39413824)</sub>

<!-- /greptile_comment -->