### PR TITLE
Fix commentTrigger handler expiry

### DIFF
--- a/src/__tests__/commentHandler.test.ts
+++ b/src/__tests__/commentHandler.test.ts
@@ -1,0 +1,85 @@
+import Core, { type A_ANY } from "@xpadev-net/niwango-core";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import type { Comment } from "@/@types/comment";
+import {
+  addHandler,
+  handlers,
+  resetHandlers,
+  triggerHandlers,
+} from "@/contexts/commentHandler";
+
+const createComment = (vpos: number, message = "hello"): Comment =>
+  ({
+    _vpos: vpos,
+    message,
+  }) as Comment;
+
+describe("comment handlers", () => {
+  const script: A_ANY = { type: "Raw", value: "script" };
+  let execute: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    resetHandlers();
+    execute = vi.spyOn(Core, "execute").mockReturnValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("fires handlers before their duration expires", () => {
+    const globalScope = {};
+    const scopes = [globalScope, {}, Core.prototypeScope];
+
+    addHandler(script, scopes, [], 100, 50);
+    triggerHandlers(createComment(120));
+
+    expect(execute).toHaveBeenCalledOnce();
+    expect(execute).toHaveBeenCalledWith(script, scopes, [script]);
+    expect(globalScope).toMatchObject({ chat: createComment(120) });
+    expect(handlers).toHaveLength(1);
+  });
+
+  test("removes expired handlers without firing them", () => {
+    addHandler(script, [{}], [], 100, 50);
+
+    triggerHandlers(createComment(150));
+
+    expect(execute).not.toHaveBeenCalled();
+    expect(handlers).toHaveLength(0);
+  });
+
+  test("keeps the handler list bounded while adding after expiry", () => {
+    for (let i = 0; i < 100; i++) {
+      addHandler(script, [{}], [], i * 2, 1);
+    }
+
+    expect(handlers).toHaveLength(1);
+  });
+
+  test("preserves handler registration during dispatch", () => {
+    const firstScript: A_ANY = { type: "Raw", value: "first" };
+    const secondScript: A_ANY = { type: "Raw", value: "second" };
+    const scopes = [{}, {}, Core.prototypeScope];
+
+    execute.mockImplementation((executedScript) => {
+      if (executedScript === firstScript) {
+        addHandler(secondScript, scopes, [], 120, 50);
+      }
+      return undefined;
+    });
+
+    addHandler(firstScript, scopes, [], 100, 50);
+    triggerHandlers(createComment(120));
+
+    expect(execute).toHaveBeenCalledTimes(2);
+    expect(execute).toHaveBeenNthCalledWith(1, firstScript, scopes, [
+      firstScript,
+    ]);
+    expect(execute).toHaveBeenNthCalledWith(2, secondScript, scopes, [
+      secondScript,
+    ]);
+    expect(handlers).toHaveLength(2);
+  });
+});

--- a/src/contexts/commentHandler.ts
+++ b/src/contexts/commentHandler.ts
@@ -12,6 +12,18 @@ const resetHandlers = () => {
   handlers = [];
 };
 
+const isExpiredHandler = (handler: IHandler, time: number) =>
+  handler.duration !== undefined && handler.time + handler.duration <= time;
+
+const removeExpiredHandlers = (time: number) => {
+  for (let i = handlers.length - 1; i >= 0; i--) {
+    const handler = handlers[i];
+    if (handler && isExpiredHandler(handler, time)) {
+      handlers.splice(i, 1);
+    }
+  }
+};
+
 const addHandler = (
   script: A_ANY,
   scopes: T_scope[],
@@ -19,6 +31,7 @@ const addHandler = (
   time: number,
   duration?: number,
 ) => {
+  removeExpiredHandlers(time);
   handlers.push({
     script,
     scopes,
@@ -34,6 +47,7 @@ const setHandlers = (newHandlers: IHandler[]) => {
 };
 
 const triggerHandlers = (comment: Comment) => {
+  removeExpiredHandlers(comment._vpos);
   if (comment.message.startsWith("/")) return;
   for (const handler of handlers) {
     const globalScope = getGlobalScope(handler.scopes);


### PR DESCRIPTION
## Summary
- prune commentTrigger handlers when their duration has expired
- keep handler cleanup in-place so handler registration during dispatch preserves existing behavior
- add focused tests for active, expired, bounded cleanup, and dispatch-time registration cases

## Validation
- pnpm test
- pnpm lint
- pnpm build

## Review
- deep-review self-review completed
- independent subagent review completed; first finding fixed, second pass had no actionable findings

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where `commentTrigger` handlers were never pruned after their duration expired, causing them to accumulate and fire indefinitely. It adds `isExpiredHandler` / `removeExpiredHandlers` helpers called both at `addHandler` registration time and at the top of `triggerHandlers`, plus a focused test suite covering active, expired, bounded-growth, and dispatch-time registration scenarios.

- **`commentHandler.ts`**: adds backwards-splice cleanup in both `addHandler` and `triggerHandlers`; the expiry predicate `handler.time + handler.duration <= time` correctly prunes handlers at their expiry boundary.
- **`commentHandler.test.ts`**: four new tests verify the expected lifecycle — active handlers fire, expired ones are silently dropped, the list stays bounded under rapid add-after-expiry, and handlers registered mid-dispatch are executed in the same pass.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix is self-contained, the expiry boundary and splice order are correct, and all meaningful lifecycle paths are covered by new tests.

The backwards-splice loop in removeExpiredHandlers is the standard safe way to mutate an array while scanning it. The pre-loop removeExpiredHandlers call in triggerHandlers guarantees that any addHandler invoked mid-dispatch cannot expire handlers still being iterated, closing the only tricky interaction between cleanup and live iteration. The expiry predicate (<=) correctly drops handlers at the instant they expire, consistent with every test assertion.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/contexts/commentHandler.ts | Adds expiry helpers wired into both addHandler and triggerHandlers; backwards splice avoids iterator invalidation, <= boundary matches tests, and pre-loop cleanup ensures mid-dispatch addHandler calls cannot expire surviving handlers. |
| src/__tests__/commentHandler.test.ts | New test file covering all key lifecycle paths: active handler fires, expired handler dropped at boundary, bounded-growth invariant, and mid-dispatch registration picked up in the same loop pass. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant commentHandler
    participant handlers as handlers[]
    participant Core

    Caller->>commentHandler: addHandler(script, scopes, trace, time, duration)
    commentHandler->>handlers: removeExpiredHandlers(time)
    Note over handlers: splice out handlers where time + duration <= current time
    commentHandler->>handlers: push new handler

    Caller->>commentHandler: triggerHandlers(comment)
    commentHandler->>handlers: removeExpiredHandlers(comment._vpos)
    Note over handlers: pre-loop cleanup
    loop for each handler
        commentHandler->>Core: execute(handler.script, handler.scopes, [handler.script])
        Core-->>commentHandler: "addHandler(newScript, ..., time <= _vpos)"
        commentHandler->>handlers: removeExpiredHandlers(time)
        commentHandler->>handlers: push new handler
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant commentHandler
    participant handlers as handlers[]
    participant Core

    Caller->>commentHandler: addHandler(script, scopes, trace, time, duration)
    commentHandler->>handlers: removeExpiredHandlers(time)
    Note over handlers: splice out handlers where time + duration <= current time
    commentHandler->>handlers: push new handler

    Caller->>commentHandler: triggerHandlers(comment)
    commentHandler->>handlers: removeExpiredHandlers(comment._vpos)
    Note over handlers: pre-loop cleanup
    loop for each handler
        commentHandler->>Core: execute(handler.script, handler.scopes, [handler.script])
        Core-->>commentHandler: "addHandler(newScript, ..., time <= _vpos)"
        commentHandler->>handlers: removeExpiredHandlers(time)
        commentHandler->>handlers: push new handler
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix comment trigger handler expiry"](https://github.com/xpadev-net/niwango.js/commit/62a75dc5d2a2c4c71909b3b6a1e220e8ba274e72) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39414692)</sub>

<!-- /greptile_comment -->