### PR TITLE
Fix bold drawText font weight

### DIFF
--- a/src/@types/flashText.d.ts
+++ b/src/@types/flashText.d.ts
@@ -12,6 +12,7 @@ export type measureTextInput = {
   font: commentFont;
   lineCount: number;
   size: number;
+  bold?: boolean;
 };
 
 export type charItem = compatFillItem | normalCharItem | compatSpaceItem;

--- a/src/@types/fonts.d.ts
+++ b/src/@types/fonts.d.ts
@@ -10,7 +10,7 @@ export type HTML5Fonts = "defont";
 export type FontItem = {
   font: string;
   offset: number;
-  weight: number;
+  weight: number | string;
 };
 export type platformFont = {
   [key in HTML5Fonts]: FontItem;

--- a/src/__tests__/drawTextBold.test.ts
+++ b/src/__tests__/drawTextBold.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { resetCanvas } from "@/contexts/canvas";
+import { config, initConfig } from "@/definition/config";
+import { IrText } from "@/objects/text";
+import { parseFont } from "@/utils/utils";
+
+type FontUse = {
+  type: "measure" | "fill";
+  font: string;
+};
+
+type MockCanvasContext = {
+  clearRect: ReturnType<typeof vi.fn>;
+  drawImage: ReturnType<typeof vi.fn>;
+  fillRect: ReturnType<typeof vi.fn>;
+  fillText: ReturnType<typeof vi.fn>;
+  measureText: ReturnType<typeof vi.fn>;
+  restore: ReturnType<typeof vi.fn>;
+  save: ReturnType<typeof vi.fn>;
+  scale: ReturnType<typeof vi.fn>;
+  strokeRect: ReturnType<typeof vi.fn>;
+  strokeText: ReturnType<typeof vi.fn>;
+  font: string;
+};
+
+const createMockContext = (fontUses: FontUse[]): MockCanvasContext => {
+  let currentFont = "";
+  return {
+    clearRect: vi.fn(),
+    drawImage: vi.fn(),
+    fillRect: vi.fn(),
+    fillText: vi.fn(() => {
+      fontUses.push({ type: "fill", font: currentFont });
+    }),
+    measureText: vi.fn(() => {
+      fontUses.push({ type: "measure", font: currentFont });
+      return { width: currentFont.startsWith("700") ? 18 : 12 };
+    }),
+    restore: vi.fn(),
+    save: vi.fn(),
+    scale: vi.fn(),
+    strokeRect: vi.fn(),
+    strokeText: vi.fn(),
+    get font() {
+      return currentFont;
+    },
+    set font(value: string) {
+      currentFont = value;
+    },
+  };
+};
+
+describe("drawText bold font weight", () => {
+  let fontUses: FontUse[];
+
+  beforeEach(() => {
+    initConfig();
+    resetCanvas();
+    fontUses = [];
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockImplementation(
+      () => createMockContext(fontUses) as unknown as CanvasRenderingContext2D,
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    resetCanvas();
+  });
+
+  test("keeps the configured weight for measurement and drawing when bold is false", () => {
+    new IrText({ text: "text", size: 20, bold: false });
+
+    expect(fontUses).toContainEqual({
+      type: "measure",
+      font: expect.stringMatching(/^600 20px /),
+    });
+    expect(fontUses).toContainEqual({
+      type: "fill",
+      font: expect.stringMatching(/^600 20px /),
+    });
+  });
+
+  test("uses a bolder weight for measurement and drawing when bold is true", () => {
+    new IrText({ text: "text", size: 20, bold: true });
+
+    expect(fontUses).toContainEqual({
+      type: "measure",
+      font: expect.stringMatching(/^700 20px /),
+    });
+    expect(fontUses).toContainEqual({
+      type: "fill",
+      font: expect.stringMatching(/^700 20px /),
+    });
+  });
+
+  test("promotes CSS keyword font weights without replacing the style token", () => {
+    config.fonts.defont.weight = "normal";
+    config.font.gulim = "normal normal [size]px gulim, sans-serif";
+
+    expect(parseFont("defont", 20, { bold: true })).toMatch(/^bold 20px /);
+    expect(parseFont("gulim", 20, { bold: true })).toBe(
+      "normal bold 20px gulim, sans-serif",
+    );
+  });
+
+  test("adds a bold weight when a font template omits weight", () => {
+    config.font.gulim = "[size]px gulim, sans-serif";
+
+    expect(parseFont("gulim", 20, { bold: true })).toBe(
+      "700 20px gulim, sans-serif",
+    );
+  });
+});

--- a/src/objects/text.ts
+++ b/src/objects/text.ts
@@ -172,8 +172,11 @@ class IrText extends IrObject {
   }
 
   __updateFont() {
-    getCanvas(this.__id).context.font =
-      `normal 600 ${this.__size}px Arial, "ＭＳ Ｐゴシック", "MS PGothic", MSPGothic, MS-PGothic`;
+    getCanvas(this.__id).context.font = parseFont(
+      this.parsedComment.font,
+      this.__size,
+      { bold: this.bold },
+    );
   }
 
   override __updateColor() {
@@ -196,6 +199,7 @@ class IrText extends IrObject {
     const result = measure(getCanvas(this.__id).context, {
       ...this.parsedComment,
       size: this.__size,
+      bold: this.bold,
     });
     this.__actualWidth = result.width;
     this.__actualHeight = result.height;
@@ -221,7 +225,9 @@ class IrText extends IrObject {
       context.scale(-1, -1);
     }
     const lineOffset = this.parsedComment.lineOffset;
-    context.font = parseFont(this.parsedComment.font, this.__size);
+    context.font = parseFont(this.parsedComment.font, this.__size, {
+      bold: this.bold,
+    });
     context.globalAlpha = (100 - this.options.alpha) / 100;
     if (this.filter === "kage") {
       const offset = this.__kageShadowOffset();
@@ -241,7 +247,7 @@ class IrText extends IrObject {
     for (const item of this.parsedComment.content) {
       if (lastFont !== getValue(item.font, this.parsedComment.font)) {
         lastFont = getValue(item.font, this.parsedComment.font);
-        context.font = parseFont(lastFont, this.__size);
+        context.font = parseFont(lastFont, this.__size, { bold: this.bold });
       }
       if (item.type === "normal") {
         const lines = item.content.split(/[\n\r]/g);

--- a/src/objects/text.ts
+++ b/src/objects/text.ts
@@ -159,6 +159,7 @@ class IrText extends IrObject {
 
   set bold(val) {
     this.options.bold = val;
+    this.__updateFont();
     this.__modified = true;
   }
 

--- a/src/utils/flashText.ts
+++ b/src/utils/flashText.ts
@@ -259,7 +259,9 @@ const measure = (
   let currentWidth = 0;
   for (const item of comment.content) {
     const widths = [];
-    context.font = parseFont(getValue(item.font, comment.font), comment.size);
+    context.font = parseFont(getValue(item.font, comment.font), comment.size, {
+      bold: comment.bold,
+    });
     if (item.type === "normal") {
       const lines = item.content.replace(/\r\n?/g, "\n").split(/\n/);
       let count = 0;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -16,19 +16,68 @@ const getGlobalScope = (scopes: T_scope[]): T_scope | undefined => {
   }
 };
 
+type FontOptions = {
+  bold?: boolean;
+};
+
+const FONT_WEIGHT_KEYWORDS = new Set(["normal", "bold", "bolder", "lighter"]);
+
+const isFontWeight = (weight: string): boolean => {
+  return /^\d+$/.test(weight) || FONT_WEIGHT_KEYWORDS.has(weight.toLowerCase());
+};
+
+const toBoldWeight = (weight: string | number): string => {
+  const value = `${weight}`;
+  const normalized = value.trim().toLowerCase();
+  if (/^\d+$/.test(normalized)) {
+    return `${Math.max(Number(normalized), 700)}`;
+  }
+  if (normalized === "bold" || normalized === "bolder") {
+    return value;
+  }
+  return "bold";
+};
+
+const applyBoldToFontString = (font: string): string => {
+  const sizeMatch = font.match(/\b\d+(?:\.\d+)?px\b/);
+  if (!sizeMatch || sizeMatch.index === undefined) {
+    return `700 ${font}`;
+  }
+  const prefix = font.slice(0, sizeMatch.index);
+  const suffix = font.slice(sizeMatch.index);
+  const tokens = prefix.trim().split(/\s+/).filter(Boolean);
+  for (let index = tokens.length - 1; index >= 0; index -= 1) {
+    const token = tokens[index];
+    if (token !== undefined && isFontWeight(token)) {
+      tokens[index] = toBoldWeight(token);
+      return `${tokens.join(" ")} ${suffix}`;
+    }
+  }
+  return tokens.length > 0
+    ? `${tokens.join(" ")} 700 ${suffix}`
+    : `700 ${suffix}`;
+};
+
 /**
  * フォント名とサイズをもとにcontextで使えるフォントを生成する
  * @param font
  * @param size
  * @returns
  */
-const parseFont = (font: commentFont, size: string | number): string => {
+const parseFont = (
+  font: commentFont,
+  size: string | number,
+  options: FontOptions = {},
+): string => {
+  const bold = options.bold ?? false;
   switch (font) {
     case "gulim":
     case "simsun":
-      return config.font[font].replace("[size]", `${size}`);
+      return bold
+        ? applyBoldToFontString(config.font[font].replace("[size]", `${size}`))
+        : config.font[font].replace("[size]", `${size}`);
     default:
-      return `${config.fonts.defont.weight} ${size}px ${config.fonts.defont.font}`;
+      return `${bold ? toBoldWeight(config.fonts.defont.weight) : config.fonts.defont.weight} ${size}px ${config.fonts.defont.font}`;
   }
 };
 


### PR DESCRIPTION
## Summary
- Thread the drawText `bold` option through font measurement and drawing.
- Centralize bold font-weight formatting in `parseFont`, including CSS keyword weights like `normal`.
- Add regression coverage for bold=true/false font strings, keyword weights, and future templates without an explicit weight.

Supersedes stale PR #28.

## Validation
- pnpm test src/__tests__/drawTextBold.test.ts
- pnpm test
- pnpm lint
- pnpm build
- pre-commit hook: biome-check, check-types, test

## Review
- Self-review with deep-review checklist
- Independent subagent review: no actionable findings

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes `drawText`'s `bold` option being silently ignored during both font measurement and drawing by threading it through `parseFont`, `measure`, `__updateFont`, and `__draw`. It also centralizes bold weight promotion logic in new helpers (`toBoldWeight`, `applyBoldToFontString`) and widens `FontItem.weight` to accept CSS keyword strings.

- **`src/utils/utils.ts`**: New `applyBoldToFontString` parses the font string, locates the rightmost weight token before the `px` size, and promotes it (numeric: `max(w, 700)`; keyword: `normal`/`lighter` → `bold`); `parseFont` now accepts a `FontOptions` bag and delegates to these helpers.
- **`src/objects/text.ts`**: `bold` setter now calls `__updateFont()` eagerly (matching `size`/`scale` setters), and `bold` is passed into every `parseFont` and `measure` call.
- **`src/__tests__/drawTextBold.test.ts`**: Four focused tests cover the weight-preservation, weight-promotion, keyword-weight, and template-without-weight paths.
</details>


<h3>Confidence Score: 5/5</h3>

The change is narrowly scoped to font-string construction and the bold flag propagation path; no data, persistence, or auth logic is touched.

All three call sites (__updateFont, measure, __draw) consistently receive the bold flag, the new helpers are well-tested across every branch, and the previously reported inconsistency in the bold setter has been addressed.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/utils/utils.ts | Adds applyBoldToFontString, isFontWeight, toBoldWeight helpers and threads a bold option through parseFont; logic is correct for all CSS font shorthand token orderings. |
| src/objects/text.ts | Threads bold through __updateFont, __measure, and __draw; bold setter now eagerly calls __updateFont() consistent with size and scale setters. |
| src/utils/flashText.ts | Passes bold from measureTextInput into parseFont during per-item width measurement. |
| src/__tests__/drawTextBold.test.ts | New test suite covering bold=false, bold=true, CSS keyword weights, and templates without an explicit weight; all branches of the new helpers are exercised. |
| src/@types/flashText.d.ts | Adds optional bold?: boolean to measureTextInput to carry the flag into measurement. |
| src/@types/fonts.d.ts | Widens FontItem.weight from number to number | string to allow CSS keyword weights like 'normal'. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["IrText constructor / setter"] -->|"bold, font, size"| B["__updateFont()"]
    A -->|"bold, font, size"| C["__measure()"]
    A -->|"bold, font, size"| D["__draw()"]

    B --> E["parseFont(font, size, {bold})"]
    C --> F["measure(context, {..., bold})"]
    D --> E

    F --> G["parseFont(itemFont, size, {bold})"]

    E --> H{"font type?"}
    H -->|"gulim / simsun"| I["config.font[font].replace('[size]', size)"]
    I -->|"bold=true"| J["applyBoldToFontString(str)"]
    J --> K{"weight token found before px?"}
    K -->|"yes"| L["toBoldWeight(token)"]
    K -->|"no, tokens exist"| M["insert 700 before px"]
    K -->|"no tokens"| N["prepend 700"]
    H -->|"defont"| O["config.fonts.defont.weight"]
    O -->|"bold=true"| P["toBoldWeight(weight)"]

    L --> Q["CSS font string"]
    M --> Q
    N --> Q
    P --> Q
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["IrText constructor / setter"] -->|"bold, font, size"| B["__updateFont()"]
    A -->|"bold, font, size"| C["__measure()"]
    A -->|"bold, font, size"| D["__draw()"]

    B --> E["parseFont(font, size, {bold})"]
    C --> F["measure(context, {..., bold})"]
    D --> E

    F --> G["parseFont(itemFont, size, {bold})"]

    E --> H{"font type?"}
    H -->|"gulim / simsun"| I["config.font[font].replace('[size]', size)"]
    I -->|"bold=true"| J["applyBoldToFontString(str)"]
    J --> K{"weight token found before px?"}
    K -->|"yes"| L["toBoldWeight(token)"]
    K -->|"no, tokens exist"| M["insert 700 before px"]
    K -->|"no tokens"| N["prepend 700"]
    H -->|"defont"| O["config.fonts.defont.weight"]
    O -->|"bold=true"| P["toBoldWeight(weight)"]

    L --> Q["CSS font string"]
    M --> Q
    N --> Q
    P --> Q
```

</a>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/objects/text.ts`, line 160-163 ([link](https://github.com/xpadev-net/niwango.js/blob/e8023f2ea597b62e997c1560ecc785dd6dc95452/src/objects/text.ts#L160-L163)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The `bold` setter only marks `__modified = true` without calling `__updateFont()`, which is inconsistent with the `size` setter (line 111) and `scale` setter (line 152) that both call it eagerly. This doesn't cause a rendering bug — `__measure()` calls `__updateFont()` before any measurement — but it leaves `context.font` stale between a `bold` assignment and the next `draw()` cycle, and differs from the pattern established by the other two setters.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/objects/text.ts
   Line: 160-163

   Comment:
   The `bold` setter only marks `__modified = true` without calling `__updateFont()`, which is inconsistent with the `size` setter (line 111) and `scale` setter (line 152) that both call it eagerly. This doesn't cause a rendering bug — `__measure()` calls `__updateFont()` before any measurement — but it leaves `context.font` stale between a `bold` assignment and the next `draw()` cycle, and differs from the pattern established by the other two setters.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fobjects%2Ftext.ts%0ALine%3A%20160-163%0A%0AComment%3A%0AThe%20%60bold%60%20setter%20only%20marks%20%60__modified%20%3D%20true%60%20without%20calling%20%60__updateFont%28%29%60%2C%20which%20is%20inconsistent%20with%20the%20%60size%60%20setter%20%28line%20111%29%20and%20%60scale%60%20setter%20%28line%20152%29%20that%20both%20call%20it%20eagerly.%20This%20doesn't%20cause%20a%20rendering%20bug%20%E2%80%94%20%60__measure%28%29%60%20calls%20%60__updateFont%28%29%60%20before%20any%20measurement%20%E2%80%94%20but%20it%20leaves%20%60context.font%60%20stale%20between%20a%20%60bold%60%20assignment%20and%20the%20next%20%60draw%28%29%60%20cycle%2C%20and%20differs%20from%20the%20pattern%20established%20by%20the%20other%20two%20setters.%0A%0A%60%60%60suggestion%0A%20%20set%20bold%28val%29%20%7B%0A%20%20%20%20this.options.bold%20%3D%20val%3B%0A%20%20%20%20this.__updateFont%28%29%3B%0A%20%20%20%20this.__modified%20%3D%20true%3B%0A%20%20%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=xpadev-net%2Fniwango.js&pr=35&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mas..."](https://github.com/xpadev-net/niwango.js/commit/630c08c8885c76b35843b6d9892db6c14cee764e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39414830)</sub>

<!-- /greptile_comment -->