### PR TITLE
Reject unsupported drawShape mask option

### DIFF
--- a/src/__tests__/shape.test.ts
+++ b/src/__tests__/shape.test.ts
@@ -1,0 +1,62 @@
+import Core, {
+  type A_CallExpression,
+  type A_Program,
+} from "@xpadev-net/niwango-core";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { initConfig } from "@/definition/config";
+import { processDrawShape } from "@/functions/drawShape";
+import { IrShape } from "@/objects/shape";
+import { setup } from "@/utils/setup";
+
+const parseCallExpression = (niwango: string) => {
+  setup();
+  const ast = Core.parseScript(niwango, "test.niwascript") as A_Program;
+  const statement = ast.body[0] as { expression: A_CallExpression } | undefined;
+  if (!statement) throw new Error("missing parsed statement");
+  return statement.expression;
+};
+
+const mockCanvasContext = () =>
+  ({
+    beginPath: vi.fn(),
+    clearRect: vi.fn(),
+    ellipse: vi.fn(),
+    fill: vi.fn(),
+    fillRect: vi.fn(),
+  }) as unknown as CanvasRenderingContext2D;
+
+describe("IrShape mask option", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("rejects unsupported mask shapes explicitly", () => {
+    expect(() => new IrShape({ mask: true })).toThrow(
+      "drawShape mask option is not supported",
+    );
+  });
+
+  test("rejects enabling mask after shape creation", () => {
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockImplementation(() =>
+      mockCanvasContext(),
+    );
+    initConfig();
+    setup();
+    const shape = new IrShape({ mask: false });
+
+    expect(() => {
+      shape.mask = true;
+    }).toThrow("drawShape mask option is not supported");
+  });
+
+  test("rejects drawShape calls with mask enabled", () => {
+    const script = parseCallExpression(
+      'drawShape(0, 0, 0, "rect", 10, 10, "naka", 16777215, true)',
+    );
+
+    expect(() =>
+      processDrawShape(script, [{}, {}, Core.prototypeScope], {}, [script]),
+    ).toThrow("drawShape mask option is not supported");
+  });
+});

--- a/src/objects/shape.ts
+++ b/src/objects/shape.ts
@@ -47,6 +47,12 @@ const defaultOptions: IShapeOptions = {
   mover: "",
 };
 
+const assertMaskSupported = (mask: unknown) => {
+  if (mask === true) {
+    throw new Error("drawShape mask option is not supported");
+  }
+};
+
 /**
  * 図形オブジェクトのクラス
  */
@@ -55,6 +61,7 @@ class IrShape extends IrObject {
   public override readonly __type: string = "IrShape";
   constructor(_options: IShapeOptionsNullable) {
     const options = format(_options, optionTypes);
+    assertMaskSupported(options.mask);
     super(options);
     this.options = getOptions(defaultOptions, options);
     this.__width = this.options.width;
@@ -109,6 +116,7 @@ class IrShape extends IrObject {
   }
 
   set mask(val) {
+    assertMaskSupported(val);
     this.options.mask = val;
   }
 


### PR DESCRIPTION
## Summary
- Reject `drawShape` / `IrShape` uses with `mask: true` using an explicit unsupported error
- Add focused regressions for direct construction, setter assignment, and `processDrawShape` argument parsing

## Validation
- pnpm vitest run src/__tests__/shape.test.ts
- pnpm test
- pnpm lint
- pnpm build

## Review
- Deep-review self pass: no actionable findings
- Independent review subagent: no actionable findings; setter gap addressed before PR

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds an explicit unsupported-feature guard for the `mask` option in `drawShape` / `IrShape`, throwing a clear error instead of silently accepting a value that has no rendering implementation. It also ships a focused regression suite covering all three entry points where `mask: true` can be introduced.

- **`src/objects/shape.ts`**: Adds `assertMaskSupported` (strict `=== true` check) called both in the constructor before `super()` and in the `set mask` setter, ensuring neither construction-time nor post-construction mutation can enable the unsupported feature.
- **`src/__tests__/shape.test.ts`**: Three tests covering direct construction (`new IrShape({ mask: true })`), setter assignment (`shape.mask = true`), and argument parsing via `processDrawShape`; canvas context is mocked only for the test that actually reaches `__draw()`.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change adds a narrow, well-tested guard with no effect on existing non-mask code paths.

The guard function is a pure, side-effect-free check placed at every write site for the `mask` field (constructor and setter). Strict equality against `true` is correct because `format()` already coerces the input to a boolean before the constructor check, and the setter is typed as `boolean`. The throw-before-`super()` pattern is valid JavaScript since `assertMaskSupported` never touches `this`. All three entry points are covered by the new tests, and the canvas mock is correctly scoped only to the test that needs it.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/objects/shape.ts | Adds `assertMaskSupported` guard called in the constructor (before `super()`) and in the `set mask` setter; logic is correct and covers both creation and post-creation mutation paths. |
| src/__tests__/shape.test.ts | New test file covering constructor rejection, setter rejection, and `processDrawShape` argument parsing; canvas mock correctly scoped to the test that needs it. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["processDrawShape(script, scopes)"] --> B["Core.utils.argumentParser(...)"]
    B --> C["new IrShape(args)"]
    C --> D["format(_options, optionTypes)"]
    D --> E["assertMaskSupported(options.mask)"]
    E -- "mask === true" --> F["throw Error('drawShape mask option is not supported')"]
    E -- "mask !== true" --> G["super(options)"]
    G --> H["getOptions(defaultOptions, options)"]
    H --> I["__draw()"]

    J["shape.mask = val"] --> K["assertMaskSupported(val)"]
    K -- "val === true" --> F
    K -- "val !== true" --> L["this.options.mask = val"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["processDrawShape(script, scopes)"] --> B["Core.utils.argumentParser(...)"]
    B --> C["new IrShape(args)"]
    C --> D["format(_options, optionTypes)"]
    D --> E["assertMaskSupported(options.mask)"]
    E -- "mask === true" --> F["throw Error('drawShape mask option is not supported')"]
    E -- "mask !== true" --> G["super(options)"]
    G --> H["getOptions(defaultOptions, options)"]
    H --> I["__draw()"]

    J["shape.mask = val"] --> K["assertMaskSupported(val)"]
    K -- "val === true" --> F
    K -- "val !== true" --> L["this.options.mask = val"]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mas..."](https://github.com/xpadev-net/niwango.js/commit/25ba9a934db52ea0c423adb33c83703c71199e38) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39415207)</sub>

<!-- /greptile_comment -->