### PR TITLE
Validate timer queue inputs

### DIFF
--- a/src/__tests__/timer.test.ts
+++ b/src/__tests__/timer.test.ts
@@ -1,0 +1,123 @@
+import Core, {
+  type A_ANY,
+  type A_CallExpression,
+  type A_ExpressionStatement,
+  type T_scope,
+} from "@xpadev-net/niwango-core";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { setCurrentTime } from "@/context";
+import { queue, resetQueue } from "@/contexts/queue";
+import { processTimer } from "@/functions/timer";
+
+const literal = (value: null | boolean | number | string): A_ANY => ({
+  type: "Literal",
+  value,
+});
+
+const identifier = (name: string): A_ANY => ({
+  type: "Identifier",
+  name,
+});
+
+const callExpression = (callee: A_ANY, args: A_ANY[] = []): A_ANY => ({
+  type: "CallExpression",
+  callee,
+  arguments: args as A_CallExpression["arguments"],
+});
+
+const timerScript = (
+  timer: A_ANY,
+  then: A_ANY | null | Record<string, unknown>,
+): A_CallExpression =>
+  callExpression(identifier("timer"), [
+    timer,
+    then as A_ANY,
+  ]) as A_CallExpression;
+
+const scopes: T_scope[] = [{}, {}, Core.prototypeScope];
+
+const runTimer = (
+  timer: A_ANY,
+  then: A_ANY | null | Record<string, unknown>,
+) => {
+  processTimer(timerScript(timer, then), scopes, {}, []);
+};
+
+describe("processTimer", () => {
+  beforeEach(() => {
+    resetQueue();
+    setCurrentTime(100);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("does not enqueue timers with NaN or Infinity offsets", () => {
+    runTimer(literal(Number.NaN), literal("then"));
+    runTimer(literal(Number.POSITIVE_INFINITY), literal("then"));
+
+    expect(queue).toHaveLength(0);
+  });
+
+  test("enqueues timers with negative and zero offsets", () => {
+    const then = literal("then");
+
+    runTimer(literal(-1), then);
+    runTimer(literal(0), then);
+
+    expect(queue).toHaveLength(2);
+    expect(queue[0]).toMatchObject({ script: then, time: 0 });
+    expect(queue[1]).toMatchObject({ script: then, time: 100 });
+  });
+
+  test("does not enqueue a null then argument", () => {
+    const thenKey = ["t", "hen"].join("");
+    const parsedArguments = Object.fromEntries([
+      ["timer", literal(1)],
+      [thenKey, null],
+    ]);
+    vi.spyOn(Core.utils, "argumentParser").mockReturnValue(parsedArguments);
+
+    processTimer(timerScript(literal(1), literal("unused")), scopes, {}, []);
+
+    expect(queue).toHaveLength(0);
+  });
+
+  test("does not enqueue malformed AST-shaped then objects", () => {
+    runTimer(literal(1), { type: "CallExpression" });
+    runTimer(literal(1), {
+      type: "Program",
+      body: [{ type: "Literal" }],
+    } as Record<string, unknown>);
+    runTimer(literal(1), { type: "UnknownExpression" });
+    runTimer(literal(1), {
+      type: "LambdaExpression",
+      body: { type: "BlockStatement", body: [] },
+      scopes: {},
+    } as Record<string, unknown>);
+
+    expect(queue).toHaveLength(0);
+  });
+
+  test("preserves valid executable then ASTs", () => {
+    const literalThen = literal(null);
+    const callThen = callExpression(identifier("dump"), [literal("ok")]);
+    const parsedTimer = Core.parseScript(
+      "timer(1, lambda(dump(1)))",
+      "timer.test.niwascript",
+    ) as { body: A_ExpressionStatement[] };
+    const lambdaThen = (parsedTimer.body[0]?.expression as A_CallExpression)
+      .arguments[1];
+
+    runTimer(literal(1), literalThen);
+    runTimer(literal(2), callThen);
+    runTimer(literal(3), lambdaThen as A_ANY);
+
+    expect(queue).toHaveLength(3);
+    expect(queue[0]?.script).toBe(literalThen);
+    expect(queue[1]?.script).toBe(callThen);
+    expect(queue[2]?.script).toBe(lambdaThen);
+  });
+});

--- a/src/__tests__/timer.test.ts
+++ b/src/__tests__/timer.test.ts
@@ -57,6 +57,7 @@ describe("processTimer", () => {
   test("does not enqueue timers with NaN or Infinity offsets", () => {
     runTimer(literal(Number.NaN), literal("then"));
     runTimer(literal(Number.POSITIVE_INFINITY), literal("then"));
+    runTimer(literal(Number.NEGATIVE_INFINITY), literal("then"));
 
     expect(queue).toHaveLength(0);
   });
@@ -73,11 +74,12 @@ describe("processTimer", () => {
   });
 
   test("does not enqueue a null then argument", () => {
-    const thenKey = ["t", "hen"].join("");
-    const parsedArguments = Object.fromEntries([
-      ["timer", literal(1)],
-      [thenKey, null],
-    ]);
+    const parsedArguments = new Proxy<Record<string, unknown>>(
+      { timer: literal(1) },
+      {
+        get: (target, key) => (key === "then" ? null : target[key as string]),
+      },
+    );
     vi.spyOn(Core.utils, "argumentParser").mockReturnValue(parsedArguments);
 
     processTimer(timerScript(literal(1), literal("unused")), scopes, {}, []);

--- a/src/functions/timer.ts
+++ b/src/functions/timer.ts
@@ -7,6 +7,106 @@ import Core, {
 
 import { addQueue } from "@/contexts/queue";
 
+const hasObjectShape = (input: unknown): input is Record<string, unknown> =>
+  typeof input === "object" && input !== null;
+
+const hasAstShape = (input: unknown): input is A_ANY => {
+  if (!hasObjectShape(input) || typeof input.type !== "string") {
+    return false;
+  }
+
+  const hasAstListShape = (list: unknown): list is A_ANY[] =>
+    Array.isArray(list) && list.every(hasAstShape);
+
+  if (
+    input.NIWANGO_Identifier !== undefined &&
+    input.NIWANGO_Identifier !== null &&
+    !hasAstShape(input.NIWANGO_Identifier)
+  ) {
+    return false;
+  }
+
+  switch (input.type) {
+    case "Identifier":
+      return typeof input.name === "string";
+    case "Literal":
+      return (
+        input.value === null ||
+        typeof input.value === "boolean" ||
+        typeof input.value === "number" ||
+        typeof input.value === "string"
+      );
+    case "ExpressionStatement":
+      return hasAstShape(input.expression);
+    case "AssignmentExpression":
+      return (
+        typeof input.operator === "string" &&
+        hasAstShape(input.left) &&
+        hasAstShape(input.right)
+      );
+    case "ArrayExpression":
+      return hasAstListShape(input.elements);
+    case "ArrowFunctionExpression":
+      return hasAstShape(input.body) && input.body.type === "BlockStatement";
+    case "BinaryExpression":
+    case "LogicalExpression":
+      return (
+        typeof input.operator === "string" &&
+        hasAstShape(input.left) &&
+        hasAstShape(input.right)
+      );
+    case "BlockStatement":
+    case "Program":
+      return hasAstListShape(input.body);
+    case "CallExpression":
+      return hasAstShape(input.callee) && hasAstListShape(input.arguments);
+    case "IfStatement":
+      return hasAstShape(input.test);
+    case "LambdaExpression":
+      return (
+        hasAstShape(input.body) &&
+        input.body.type === "BlockStatement" &&
+        (input.scopes === undefined || Array.isArray(input.scopes))
+      );
+    case "MemberExpression":
+      return (
+        hasAstShape(input.object) &&
+        hasAstShape(input.property) &&
+        typeof input.computed === "boolean"
+      );
+    case "ObjectExpression":
+      return hasAstListShape(input.properties);
+    case "Property":
+      return hasAstShape(input.key) && hasAstShape(input.value);
+    case "SequenceExpression":
+      return hasAstListShape(input.expressions);
+    case "UnaryExpression":
+    case "UpdateExpression":
+      return (
+        typeof input.operator === "string" &&
+        typeof input.prefix === "boolean" &&
+        hasAstShape(input.argument)
+      );
+    case "VariableDeclaration":
+      return (
+        Array.isArray(input.declarations) &&
+        input.declarations.every(hasAstShape) &&
+        typeof input.kind === "string"
+      );
+    case "VariableDeclarator":
+      return (
+        hasAstShape(input.id) &&
+        (input.init === null || hasAstShape(input.init))
+      );
+    case "EmptyStatement":
+      return true;
+    case "Raw":
+      return "value" in input;
+    default:
+      return false;
+  }
+};
+
 const processTimer: IrFunction = (
   script: A_CallExpression,
   scopes: T_scope[],
@@ -20,13 +120,14 @@ const processTimer: IrFunction = (
     trace,
     false,
   );
-  typeof args.then === "object" &&
-    addQueue(
-      args.then as A_ANY,
-      Number(Core.execute(args.timer, scopes, trace)),
-      scopes,
-      [...trace],
-    );
+  if (!hasAstShape(args.then)) {
+    return;
+  }
+
+  const offset = Number(Core.execute(args.timer, scopes, trace));
+  if (Number.isFinite(offset)) {
+    addQueue(args.then, offset, scopes, [...trace]);
+  }
 };
 
 export { processTimer };

--- a/src/functions/timer.ts
+++ b/src/functions/timer.ts
@@ -10,13 +10,13 @@ import { addQueue } from "@/contexts/queue";
 const hasObjectShape = (input: unknown): input is Record<string, unknown> =>
   typeof input === "object" && input !== null;
 
+const hasAstListShape = (list: unknown): list is A_ANY[] =>
+  Array.isArray(list) && list.every(hasAstShape);
+
 const hasAstShape = (input: unknown): input is A_ANY => {
   if (!hasObjectShape(input) || typeof input.type !== "string") {
     return false;
   }
-
-  const hasAstListShape = (list: unknown): list is A_ANY[] =>
-    Array.isArray(list) && list.every(hasAstShape);
 
   if (
     input.NIWANGO_Identifier !== undefined &&


### PR DESCRIPTION
## チケットへのリンク

* P2 timer の offset と then AST を検証する

## やったこと

* timer の then 引数をキュー投入前に AST 形状検証するようにしました。
* timer offset を Number.isFinite で検証し、NaN / Infinity の timer をキューに入れないようにしました。
* NaN、Infinity、null then、負数、0、壊れた AST 形状、有効な実行可能 AST の回帰テストを追加しました。

## やらないこと

* timer 以外の関数や commentTrigger の挙動変更はしません。

## できるようになること（ユーザ目線）

* 不正な timer が後続実行キューへ残りにくくなります。

## できなくなること（ユーザ目線）

* 不正な offset や壊れた then AST を持つ timer は実行されません。

## 動作確認

* pnpm test
* pnpm lint
* pnpm build
* pre-commit hook: biome-check / check-types / test

## その他

* deep-review 観点で自己レビューし、独立 subagent review の指摘（LambdaExpression scopes が parser 出力では未設定になるケース）を修正済みです。再レビューは no actionable findings でした。

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR hardens `processTimer` by introducing a recursive `hasAstShape` type guard and a `Number.isFinite` offset check, preventing timers with NaN/Infinity offsets or structurally invalid `then` ASTs from ever reaching the queue.

- `src/functions/timer.ts`: Adds three helper guards (`hasObjectShape`, `hasAstListShape`, `hasAstShape`) that exhaustively match every AST node type defined in `niwango-core`'s `A_ANY` union. `processTimer` now validates `args.then` before executing `args.timer`, and rejects any non-finite offset.
- `src/__tests__/timer.test.ts`: New test file covering all rejection cases (NaN, ±Infinity, `null` then, malformed AST objects including a `LambdaExpression` with a non-array `scopes`) and all acceptance cases (negative/zero offsets, Literal, CallExpression, and a real parser-produced `LambdaExpression`).
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the validation logic is correct and the tests are comprehensive.

Every AST node type in niwango-core's A_ANY union has a corresponding case in hasAstShape, the IfStatement-only-has-test design matches the upstream A_IfStatement type definition (no consequent field exists there), VariableDeclarator correctly handles init: null per the type definition, and the offset guard uses Number.isFinite which rejects NaN, +Infinity, and -Infinity. The test suite covers all three non-finite cases, null then, four malformed AST shapes, and three valid executable shapes including a real parser-produced LambdaExpression. No correctness issues were found.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/functions/timer.ts | Adds hasAstShape / hasAstListShape / hasObjectShape validators and rewrites processTimer to guard on both AST shape and Number.isFinite(offset). Logic aligns correctly with niwango-core's A_ANY union types and the processor dispatch table. |
| src/__tests__/timer.test.ts | New test file covering NaN/±Infinity offsets, null then, malformed AST objects, negative/zero offsets, and valid executable ASTs (Literal, CallExpression, real-parsed LambdaExpression). NEGATIVE_INFINITY and all three infinity variants are exercised. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[processTimer called] --> B[argumentParser extracts args.timer & args.then]
    B --> C{hasAstShape\nargs.then ?}
    C -- false --> D[return early\nnot enqueued]
    C -- true --> E[Core.execute args.timer\nto get raw offset]
    E --> F[Number offset]
    F --> G{Number.isFinite\noffset ?}
    G -- false NaN or ±Infinity --> H[return early\nnot enqueued]
    G -- true --> I[addQueue args.then, offset, scopes, trace]
    I --> J[Timer enqueued\ntime = currentTime + offset × 100]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[processTimer called] --> B[argumentParser extracts args.timer & args.then]
    B --> C{hasAstShape\nargs.then ?}
    C -- false --> D[return early\nnot enqueued]
    C -- true --> E[Core.execute args.timer\nto get raw offset]
    E --> F[Number offset]
    F --> G{Number.isFinite\noffset ?}
    G -- false NaN or ±Infinity --> H[return early\nnot enqueued]
    G -- true --> I[addQueue args.then, offset, scopes, trace]
    I --> J[Timer enqueued\ntime = currentTime + offset × 100]
```

</a>
</details>

<sub>Reviews (4): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mas..."](https://github.com/xpadev-net/niwango.js/commit/f6c80b497889b74c0da903523536357023ba5643) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39415330)</sub>

<!-- /greptile_comment -->