### PR TITLE
ci: add package smoke checks

### DIFF
--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "src/**"
       - "types/**"
+      - "tests/**"
       - "vitest.config.ts"
       - "tsconfig.json"
       - "package.json"
@@ -32,7 +33,19 @@ jobs:
       - name: Install dependencies
         run: |
           npm install -g pnpm
-          pnpm install
+          pnpm install --frozen-lockfile
+
+      - name: Run lint
+        run: pnpm lint
 
       - name: Run tests
         run: pnpm test
+
+      - name: Build package
+        run: pnpm build
+
+      - name: Check package contents
+        run: npm pack --dry-run --ignore-scripts
+
+      - name: Smoke test packed package
+        run: pnpm smoke:package

--- a/tests/smoke/package-entrypoints.mjs
+++ b/tests/smoke/package-entrypoints.mjs
@@ -32,7 +32,14 @@ const packOutput = execFileSync(
     encoding: "utf8",
   },
 ).trim();
-const [{ filename: tarballFilename }] = JSON.parse(packOutput);
+const packJsonMatch = /(?:^|\n)(\[\s*\{)/.exec(packOutput);
+if (!packJsonMatch) {
+  throw new Error(`npm pack did not return JSON output:\n${packOutput}`);
+}
+const packJsonStart = packJsonMatch.index + packJsonMatch[0].indexOf("[");
+const [{ filename: tarballFilename }] = JSON.parse(
+  packOutput.slice(packJsonStart),
+);
 const tarball = join(packDirectory, tarballFilename);
 
 writeFileSync(


### PR DESCRIPTION
## Summary
- install dependencies with `pnpm install --frozen-lockfile` in the Vitest workflow
- add lint, build, npm pack dry-run, and packed-package smoke steps
- trigger the workflow when smoke tests under `tests/**` change

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm test`
- `pnpm lint`
- `pnpm build`
- `npm pack --dry-run --ignore-scripts`
- `pnpm smoke:package`
- `git diff --check`
- workflow YAML parse via Ruby YAML loader
- `actionlint` unavailable locally

## Review
- deep-review automation/artifact pass: no actionable findings
- independent subagent review: no actionable findings; residual risk is no live GitHub Actions execution before PR

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR hardens the CI pipeline by adding `--frozen-lockfile` to the `pnpm install` step and introducing lint, build, dry-run pack, and packed-package smoke checks as sequential workflow steps. It also fixes a latent crash in the smoke test script where `JSON.parse` would fail if `npm pack --json` prefixed its JSON output with warning/notice lines.

- **Workflow (`.github/workflows/vitest.yml`)**: adds `tests/**` to the push trigger, locks the lock file on install, and chains four new CI steps (lint → build → pack dry-run → smoke test) after the existing Vitest step.
- **Smoke test (`tests/smoke/package-entrypoints.mjs`)**: replaces a bare `JSON.parse(packOutput)` with a regex that finds where the JSON array begins in stdout, so prepended npm warnings no longer crash the parse.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are additive CI improvements with no modifications to production source code or build configuration.

Both changed files are CI infrastructure only. The workflow additions follow a correct, well-ordered pipeline (install → lint → test → build → pack → smoke), and the --frozen-lockfile flag is a strict improvement. The regex-based JSON slicing in the smoke script correctly handles both the at-start and newline-prefixed match positions, and the failure message on a non-match is descriptive. No production code paths are touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/vitest.yml | Adds tests/** trigger path and five new CI steps (frozen-lockfile install, lint, build, dry-run pack, smoke test); ordering and commands are correct. |
| tests/smoke/package-entrypoints.mjs | Adds regex-based JSON-start detection to handle npm stdout that prepends warning/notice lines before the JSON array; logic is correct for both at-start and mid-string match positions. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[push to src/**, types/**, tests/**, config files] --> B[Checkout]
    B --> C[Setup Node 22]
    C --> D[npm install -g pnpm\npnpm install --frozen-lockfile]
    D --> E[pnpm lint\nbiome check + tsc --noEmit]
    E --> F[pnpm test\nVitest run]
    F --> G[pnpm build\nrolldown + DTS emit]
    G --> H[npm pack --dry-run --ignore-scripts\nVerify pack contents]
    H --> I[pnpm smoke:package\ntests/smoke/package-entrypoints.mjs]
    I --> J{npm pack --json\nFind JSON start in stdout}
    J --> K[Install tarball in temp consumer dir]
    K --> L[node esm.mjs\nESM entrypoint check]
    K --> M[node cjs.cjs\nCJS entrypoint check]
    K --> N[tsc --project tsconfig.json\nType declaration check]
    L & M & N --> O[All checks passed]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[push to src/**, types/**, tests/**, config files] --> B[Checkout]
    B --> C[Setup Node 22]
    C --> D[npm install -g pnpm\npnpm install --frozen-lockfile]
    D --> E[pnpm lint\nbiome check + tsc --noEmit]
    E --> F[pnpm test\nVitest run]
    F --> G[pnpm build\nrolldown + DTS emit]
    G --> H[npm pack --dry-run --ignore-scripts\nVerify pack contents]
    H --> I[pnpm smoke:package\ntests/smoke/package-entrypoints.mjs]
    I --> J{npm pack --json\nFind JSON start in stdout}
    J --> K[Install tarball in temp consumer dir]
    K --> L[node esm.mjs\nESM entrypoint check]
    K --> M[node cjs.cjs\nCJS entrypoint check]
    K --> N[tsc --project tsconfig.json\nType declaration check]
    L & M & N --> O[All checks passed]
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mas..."](https://github.com/xpadev-net/niwango.js/commit/672a0ab6b7347361a8f516b0f0ea2b8936a5116a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39420903)</sub>

<!-- /greptile_comment -->