### PR TITLE
Align vitest dependency declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,6 @@
     "typedoc": "^0.25.13",
     "typedoc-plugin-missing-exports": "^2.3.0",
     "typescript": "^5.9.3",
-    "vitest": "^1.6.1"
+    "vitest": "^3.2.6"
   }
 }


### PR DESCRIPTION
## Summary
- Align package.json devDependency vitest range with the existing pnpm lockfile importer and workspace override resolution at 3.2.6.
- Leave pnpm-lock.yaml and pnpm-workspace.yaml unchanged because pnpm install reported the lockfile is already up to date.

## Validation
- pnpm install
- pnpm install --frozen-lockfile
- pnpm test
- pnpm lint
- pnpm build
- pnpm smoke:package
- git diff --check
- pre-commit hook: check-types and test

## Review
- Deep-review self pass: no actionable findings.
- Independent subagent artifact/dependency review: no actionable findings.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR aligns the `vitest` devDependency declared in `package.json` with the version already resolved at runtime. A workspace override in `pnpm-workspace.yaml` (`vitest@<3.2.6: ^3.2.6`) was already forcing pnpm to install vitest 3.2.6 regardless of the old `^1.6.1` range, so the lockfile was already up to date before this change.

- Updates `vitest` in `package.json` `devDependencies` from `^1.6.1` to `^3.2.6`, matching the workspace override and the locked version.
- No changes to `pnpm-lock.yaml` or `pnpm-workspace.yaml` are required because the lockfile was already correct.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the declared range now matches what was already being installed.

The only changed line brings the package.json vitest range into agreement with the workspace override and the existing lockfile. The lockfile itself is unchanged, so nothing about the installed dependency tree is actually different before and after this PR lands.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | Updates the `vitest` devDependency range from `^1.6.1` to `^3.2.6`, aligning the declared range with the version already resolved by the pnpm workspace override (`vitest@<3.2.6: ^3.2.6` in `pnpm-workspace.yaml`) and confirmed in the lockfile. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["package.json\nvitest: ^3.2.6 (was ^1.6.1)"] --> B["pnpm-workspace.yaml\noverride: vitest@<3.2.6 → ^3.2.6"]
    B --> C["pnpm-lock.yaml\nvitest@3.2.6 (unchanged)"]
    C --> D["Installed: vitest 3.2.6"]
    A --> D
    style A fill:#d4edda,stroke:#28a745
    style B fill:#fff3cd,stroke:#ffc107
    style C fill:#d1ecf1,stroke:#17a2b8
    style D fill:#d4edda,stroke:#28a745
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["package.json\nvitest: ^3.2.6 (was ^1.6.1)"] --> B["pnpm-workspace.yaml\noverride: vitest@<3.2.6 → ^3.2.6"]
    B --> C["pnpm-lock.yaml\nvitest@3.2.6 (unchanged)"]
    C --> D["Installed: vitest 3.2.6"]
    A --> D
    style A fill:#d4edda,stroke:#28a745
    style B fill:#fff3cd,stroke:#ffc107
    style C fill:#d1ecf1,stroke:#17a2b8
    style D fill:#d4edda,stroke:#28a745
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Align vitest dependency declaration"](https://github.com/xpadev-net/niwango.js/commit/7c12966e2769da869b735abef3a33f2645b0ffb6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39426910)</sub>

<!-- /greptile_comment -->