### PR TITLE
Normalize flash text newlines

### DIFF
--- a/src/__tests__/flashTextNewline.test.ts
+++ b/src/__tests__/flashTextNewline.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { resetCanvas } from "@/contexts/canvas";
+import { config, initConfig } from "@/definition/config";
+import { IrText } from "@/objects/text";
+import { measure, parse } from "@/utils/flashText";
+
+type MockCanvasContext = {
+  clearRect: ReturnType<typeof vi.fn>;
+  drawImage: ReturnType<typeof vi.fn>;
+  fillRect: ReturnType<typeof vi.fn>;
+  fillText: ReturnType<typeof vi.fn>;
+  measureText: ReturnType<typeof vi.fn>;
+  restore: ReturnType<typeof vi.fn>;
+  save: ReturnType<typeof vi.fn>;
+  scale: ReturnType<typeof vi.fn>;
+  strokeRect: ReturnType<typeof vi.fn>;
+  strokeText: ReturnType<typeof vi.fn>;
+  font: string;
+};
+
+const createMockContext = (): MockCanvasContext => {
+  let currentFont = "";
+  return {
+    clearRect: vi.fn(),
+    drawImage: vi.fn(),
+    fillRect: vi.fn(),
+    fillText: vi.fn(),
+    measureText: vi.fn((text: string) => ({ width: text.length * 10 })),
+    restore: vi.fn(),
+    save: vi.fn(),
+    scale: vi.fn(),
+    strokeRect: vi.fn(),
+    strokeText: vi.fn(),
+    get font() {
+      return currentFont;
+    },
+    set font(value: string) {
+      currentFont = value;
+    },
+  };
+};
+
+describe("flash text newline normalization", () => {
+  let contexts: MockCanvasContext[];
+
+  beforeEach(() => {
+    initConfig();
+    resetCanvas();
+    contexts = [];
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockImplementation(
+      () => {
+        const context = createMockContext();
+        contexts.push(context);
+        return context as unknown as CanvasRenderingContext2D;
+      },
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    resetCanvas();
+  });
+
+  test.each([
+    "a\nb",
+    "a\r\nb",
+    "a\rb",
+  ])("parses %j as two normalized lines", (text) => {
+    const parsed = parse(text);
+
+    expect(parsed.lineCount).toBe(2);
+    expect(
+      parsed.content.every(
+        (item) => item.type !== "normal" || !item.content.includes("\r"),
+      ),
+    ).toBe(true);
+  });
+
+  test("measures LF, CRLF, and CR text with the same height", () => {
+    const context = createMockContext();
+
+    const heights = ["a\nb", "a\r\nb", "a\rb"].map((text) => {
+      const parsed = parse(text);
+      return measure(context as unknown as CanvasRenderingContext2D, {
+        ...parsed,
+        size: 20,
+      }).height;
+    });
+
+    expect(heights).toEqual([
+      20 * config.lineHeight * 2 + config.commentYPaddingTop,
+      20 * config.lineHeight * 2 + config.commentYPaddingTop,
+      20 * config.lineHeight * 2 + config.commentYPaddingTop,
+    ]);
+  });
+
+  test.each([
+    "a\nb",
+    "a\r\nb",
+    "a\rb",
+  ])("draws %j with the same visible line positions", (text) => {
+    new IrText({ text, size: 20 });
+    const context = contexts.at(-1);
+    if (!context) throw new Error("missing mocked canvas context");
+    const visibleTextCalls = context.fillText.mock.calls.filter(
+      (call) => call[0] !== "",
+    );
+
+    expect(visibleTextCalls).toHaveLength(2);
+    expect(visibleTextCalls.map((call) => call[0])).toEqual(["a", "b"]);
+    const firstCall = visibleTextCalls[0];
+    const secondCall = visibleTextCalls[1];
+    if (!firstCall || !secondCall) throw new Error("missing fillText call");
+    const firstY = Number(firstCall[2]);
+    const secondY = Number(secondCall[2]);
+    expect(secondY - firstY).toBe(20 * config.lineHeight);
+  });
+});

--- a/src/objects/text.ts
+++ b/src/objects/text.ts
@@ -5,7 +5,7 @@ import { render } from "@/context";
 import { getCanvas } from "@/contexts/canvas";
 import { config } from "@/definition/config";
 import { IrObject } from "@/objects/object";
-import { measure, parse } from "@/utils/flashText";
+import { measure, normalizeNewlines, parse } from "@/utils/flashText";
 import { number2color } from "@/utils/number2color";
 import { getOptions } from "@/utils/object";
 import { format, getValue, parseFont } from "@/utils/utils";
@@ -251,7 +251,7 @@ class IrText extends IrObject {
         context.font = parseFont(lastFont, this.__size, { bold: this.bold });
       }
       if (item.type === "normal") {
-        const lines = item.content.split(/[\n\r]/g);
+        const lines = normalizeNewlines(item.content).split(/\n/g);
         lines.forEach((line, index) => {
           const posX = leftOffset - reverseOffset;
           const posY =

--- a/src/utils/flashText.ts
+++ b/src/utils/flashText.ts
@@ -27,6 +27,12 @@ const getFontName = (font: string): commentFlashFont => {
 };
 
 /**
+ * Flash処理用に改行コードを統一する
+ * @param string
+ */
+const normalizeNewlines = (string: string) => string.replace(/\r\n?/g, "\n");
+
+/**
  * Flash処理用にコメントを分割する
  * @param string
  */
@@ -73,8 +79,9 @@ const getFontIndex = (string: string): commentContentIndex[] => {
  * @param compat
  */
 const parse = (string: string, compat = false): parsedComment => {
+  const normalizedString = normalizeNewlines(string);
   const content: commentContentItem[] = [];
-  const lines = splitContents(string);
+  const lines = splitContents(normalizedString);
   for (const line of lines) {
     const lineContent: commentContentItem[] = [];
     for (const part of line) {
@@ -96,13 +103,15 @@ const parse = (string: string, compat = false): parsedComment => {
       content.push(...lineContent);
     }
   }
-  const lineCount = Array.from(string.match(/[\n\r]/g) || []).length + 1;
+  const lineCount = Array.from(normalizedString.match(/\n/g) || []).length + 1;
   const font = content[0]?.font || "defont";
   const lineOffset =
-    (string.match(new RegExp(config.flashScriptChar.super, "g"))?.length || 0) *
+    (normalizedString.match(new RegExp(config.flashScriptChar.super, "g"))
+      ?.length || 0) *
       -1 *
       config.scriptCharOffset +
-    (string.match(new RegExp(config.flashScriptChar.sub, "g"))?.length || 0) *
+    (normalizedString.match(new RegExp(config.flashScriptChar.sub, "g"))
+      ?.length || 0) *
       config.scriptCharOffset;
   return { content, font, lineCount, lineOffset };
 };
@@ -263,7 +272,7 @@ const measure = (
       bold: comment.bold,
     });
     if (item.type === "normal") {
-      const lines = item.content.replace(/\r\n?/g, "\n").split(/\n/);
+      const lines = normalizeNewlines(item.content).split(/\n/);
       let count = 0;
       for (const value of lines) {
         const measure = context.measureText(value);
@@ -294,4 +303,4 @@ const measure = (
     config.commentYPaddingTop;
   return { width: Math.max(...width_arr, 0), height };
 };
-export { measure, parse };
+export { measure, normalizeNewlines, parse };


### PR DESCRIPTION
## Summary
- normalize CRLF/CR text input to LF before flash text parsing
- reuse the same newline normalization for measuring and drawing normal text runs
- add regression coverage for LF/CRLF/CR parse line count, measured height, and visible draw positions

## Validation
- pnpm test src/__tests__/flashTextNewline.test.ts
- pnpm test
- pnpm lint
- pnpm build

## Review
- deep-review self pass: no actionable findings
- independent subagent review: no actionable findings

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes incorrect newline handling in the Flash text pipeline by introducing a `normalizeNewlines` helper that converts `\r\n` and lone `\r` to `\n` before any parsing, measuring, or drawing occurs. Previously, CRLF inputs would be counted as two line breaks each (inflating `lineCount`) and rendered with corrupted line positions.

- **`flashText.ts`**: Adds `normalizeNewlines`, applies it at the top of `parse()` (fixing `lineCount`, `splitContents`, and script-char matching), and unifies the already-existing inline normalization in `measure()` to use the new helper. Exports the helper for reuse.
- **`text.ts`**: Replaces the ad-hoc `split(/[\n\r]/g)` in `__draw()` with `normalizeNewlines(…).split(/\n/g)`, making it consistent with the parser.
- **`flashTextNewline.test.ts`**: Adds regression tests covering LF, CRLF, and CR for `parse` line count, `measure` height, and visible `fillText` draw positions.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted normalization fix with no behavioral changes for valid LF-only input.

All three code paths (parse, measure, draw) are now consistently normalized before processing newlines. The fix is additive — already-valid LF-only strings pass through normalizeNewlines unchanged — so there is no regression risk for existing content. The new test file covers all three newline variants end-to-end across the full pipeline.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/utils/flashText.ts | Adds normalizeNewlines helper and applies it consistently across parse(), measure(), and the new export — correctly fixing CRLF/CR lineCount inflation and content splitting. |
| src/objects/text.ts | Replaces ad-hoc /[\n\r]/ split in __draw() with normalizeNewlines().split(/\n/g), making drawing consistent with the parse/measure pipeline. |
| src/__tests__/flashTextNewline.test.ts | New regression test file covering all three newline variants (LF/CRLF/CR) for parse lineCount, measure height, and fillText draw positions. Test logic correctly accounts for the empty-string calls produced by newline content items. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Input text\n(LF / CRLF / CR)"] --> B["normalizeNewlines()\n/\\r\\n?/g → '\\n'"]
    B --> C["parse()"]
    C --> D["splitContents(normalized)"]
    D --> E["parsedComment\n{ content, lineCount, font, lineOffset }"]
    E --> F["measure()\nnormalizeNewlines(item.content).split(/\\n/)"]
    E --> G["__draw()\nnormalizeNewlines(item.content).split(/\\n/g)"]
    F --> H["{ width, height }"]
    G --> I["context.fillText(line, x, y)"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["Input text\n(LF / CRLF / CR)"] --> B["normalizeNewlines()\n/\\r\\n?/g → '\\n'"]
    B --> C["parse()"]
    C --> D["splitContents(normalized)"]
    D --> E["parsedComment\n{ content, lineCount, font, lineOffset }"]
    E --> F["measure()\nnormalizeNewlines(item.content).split(/\\n/)"]
    E --> G["__draw()\nnormalizeNewlines(item.content).split(/\\n/g)"]
    F --> H["{ width, height }"]
    G --> I["context.fillText(line, x, y)"]
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mas..."](https://github.com/xpadev-net/niwango.js/commit/f8cdea8e02f30e71e53a742c14f6a01bc569c074) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39427522)</sub>

<!-- /greptile_comment -->