### PR TITLE
fix: stabilize docs playground bundle path

### DIFF
--- a/.github/workflows/create-dev-build.yml
+++ b/.github/workflows/create-dev-build.yml
@@ -34,10 +34,8 @@ jobs:
         run: sed -i -e '/\/dist/d' .gitignore
       - name: generate dev build
         run: pnpm build
-      - name: setup sandbox
-        run: |
-          cp ./dist/bundle.js ./docs/niwango.js
-          sed --in-place --expression='s/..\/dist\/bundle.js/.\/niwango.js/' docs/playground.html
+      - name: copy playground bundle
+        run: cp ./dist/browser/niwango.js ./docs/niwango.js
       - name: generate typedoc
         run: pnpm typedoc
       - name: update .gitignore

--- a/docs/bundle.js
+++ b/docs/bundle.js
@@ -1,3 +1,0 @@
-window.onload = () => {
-  document.body.innerHTML = `<div style="position: absolute;top: 50%;left: 50%;transform: translate(-50%,-50%);font-size: 50px;color: #fff;background: rgba(0,0,0,0.5);">最新版への更新をお願いします</div>`
-}

--- a/docs/playground.html
+++ b/docs/playground.html
@@ -12,7 +12,7 @@
   </div>
 </div>
 <script src="https://xpadev-net.github.io/niwango-core.js/parser.js"></script>
-<script src="../dist/bundle.js"></script>
+<script src="./niwango.js"></script>
 <script>
   const input = document.getElementById("input"),
     ast = document.getElementById("ast"),


### PR DESCRIPTION
## Summary
- Point docs/playground.html at a stable docs-relative ./niwango.js bundle path.
- Copy the actual generated browser bundle from dist/browser/niwango.js into docs/niwango.js during dev-build publishing.
- Remove the obsolete docs/bundle.js placeholder and the old HTML rewrite behavior.

## Validation
- pnpm test
- pnpm lint
- pnpm build
- git diff --check
- Ruby YAML parse for .github/workflows/create-dev-build.yml
- Lightweight smoke: copied dist/browser/niwango.js to docs/niwango.js and verified docs/playground.html resolves ./niwango.js to that copied bundle
- actionlint not installed locally

## Review
- Deep-review self pass: no actionable findings after correcting GitHub Pages /docs path contract.
- Independent subagent artifact/workflow review: no actionable findings; residual risk limited to actionlint unavailable locally.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a broken playground setup by pointing `docs/playground.html` at the stable docs-relative path `./niwango.js` and updating the dev-build workflow to copy the correct build artifact (`dist/browser/niwango.js`) to that path. The old setup was doubly broken: the HTML referenced `../dist/bundle.js` (a nonexistent path on GitHub Pages) and the workflow tried to copy the equally nonexistent `dist/bundle.js`.

- **Workflow fix**: `cp ./dist/browser/niwango.js ./docs/niwango.js` replaces the broken `cp ./dist/bundle.js ./docs/niwango.js` and eliminates the need for the runtime `sed` HTML rewrite.
- **HTML fix**: `./niwango.js` is hardcoded directly in `playground.html` so the path is stable in source control and matches what the dev-build workflow delivers.
- **Cleanup**: `docs/bundle.js` (a "please update" placeholder that was never actually loaded by the playground) is removed.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — all three changes are consistent and correct, fixing a previously broken playground deployment end-to-end.

The workflow now copies the build artifact that actually exists (dist/browser/niwango.js, confirmed in rolldown.config.mjs and package.json), the HTML path matches what the workflow delivers, and the deleted placeholder was unreferenced. No logic regressions or new failure modes introduced.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/create-dev-build.yml | Replaces broken copy of non-existent dist/bundle.js with correct copy of dist/browser/niwango.js, and removes the now-unnecessary sed rewrite of playground.html. |
| docs/playground.html | Script src updated from ../dist/bundle.js (broken path on GitHub Pages) to ./niwango.js (stable docs-relative path populated by the dev-build workflow). |
| docs/bundle.js | Deleted stale 'please update' placeholder that was never loaded by playground.html and is now superseded by the actual bundle copy step. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CI as GitHub Actions (master push)
    participant Build as pnpm build
    participant Dist as dist/browser/niwango.js
    participant Docs as docs/niwango.js
    participant Branch as dev-build branch
    participant Pages as GitHub Pages

    CI->>Build: run pnpm build
    Build-->>Dist: rolldown outputs UMD bundle
    CI->>Docs: cp dist/browser/niwango.js docs/niwango.js
    CI->>Branch: "git commit & push docs/"
    Branch-->>Pages: serve docs/
    Pages-->>Pages: playground.html loads ./niwango.js ✓
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CI as GitHub Actions (master push)
    participant Build as pnpm build
    participant Dist as dist/browser/niwango.js
    participant Docs as docs/niwango.js
    participant Branch as dev-build branch
    participant Pages as GitHub Pages

    CI->>Build: run pnpm build
    Build-->>Dist: rolldown outputs UMD bundle
    CI->>Docs: cp dist/browser/niwango.js docs/niwango.js
    CI->>Branch: "git commit & push docs/"
    Branch-->>Pages: serve docs/
    Pages-->>Pages: playground.html loads ./niwango.js ✓
```

</a>
</details>

<sub>Reviews (4): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mas..."](https://github.com/xpadev-net/niwango.js/commit/ad1e864f2999a79a77523e3cb38a5e74539c045a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39427711)</sub>

<!-- /greptile_comment -->