### PR TITLE
Fix reversed text coordinate compensation

### DIFF
--- a/src/__tests__/drawTextReverse.test.ts
+++ b/src/__tests__/drawTextReverse.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { resetCanvas } from "@/contexts/canvas";
+import { config, initConfig } from "@/definition/config";
+import { IrText } from "@/objects/text";
+
+type MockCanvasContext = {
+  clearRect: ReturnType<typeof vi.fn>;
+  drawImage: ReturnType<typeof vi.fn>;
+  fillRect: ReturnType<typeof vi.fn>;
+  fillText: ReturnType<typeof vi.fn>;
+  measureText: ReturnType<typeof vi.fn>;
+  restore: ReturnType<typeof vi.fn>;
+  save: ReturnType<typeof vi.fn>;
+  scale: ReturnType<typeof vi.fn>;
+  strokeRect: ReturnType<typeof vi.fn>;
+  strokeText: ReturnType<typeof vi.fn>;
+  font: string;
+};
+
+const createMockContext = (): MockCanvasContext => {
+  let currentFont = "";
+  return {
+    clearRect: vi.fn(),
+    drawImage: vi.fn(),
+    fillRect: vi.fn(),
+    fillText: vi.fn(),
+    measureText: vi.fn((text: string) => ({ width: text.length * 10 })),
+    restore: vi.fn(),
+    save: vi.fn(),
+    scale: vi.fn(),
+    strokeRect: vi.fn(),
+    strokeText: vi.fn(),
+    get font() {
+      return currentFont;
+    },
+    set font(value: string) {
+      currentFont = value;
+    },
+  };
+};
+
+describe("drawText reversed coordinates", () => {
+  let contexts: MockCanvasContext[];
+
+  beforeEach(() => {
+    initConfig();
+    resetCanvas();
+    contexts = [];
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockImplementation(
+      () => {
+        const context = createMockContext();
+        contexts.push(context);
+        return context as unknown as CanvasRenderingContext2D;
+      },
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    resetCanvas();
+  });
+
+  test.each([
+    { options: { text: "abc", size: -20 }, label: "negative size" },
+    { options: { text: "abc", size: 20, scale: -1 }, label: "negative scale" },
+  ])("compensates flipped text coordinates by width and height for $label", ({
+    options,
+  }) => {
+    new IrText(options);
+    const context = contexts.at(-1);
+    if (!context) throw new Error("missing mocked canvas context");
+
+    expect(context.scale).toHaveBeenCalledWith(-1, -1);
+    expect(context.fillText).toHaveBeenCalledWith(
+      "abc",
+      -30,
+      20 - (20 * config.lineHeight + config.commentYPaddingTop),
+    );
+  });
+
+  test("keeps non-reversed text coordinates unchanged", () => {
+    new IrText({ text: "abc", size: 20 });
+    const context = contexts.at(-1);
+    if (!context) throw new Error("missing mocked canvas context");
+
+    expect(context.scale).not.toHaveBeenCalled();
+    expect(context.fillText).toHaveBeenCalledWith("abc", 0, 20);
+  });
+});

--- a/src/objects/text.ts
+++ b/src/objects/text.ts
@@ -244,7 +244,8 @@ class IrText extends IrObject {
     let lastFont = this.parsedComment.font;
     let leftOffset = 0;
     let lineCount = 0;
-    const reverseOffset = this.__reverse ? this.__actualWidth : 0;
+    const reverseOffsetX = this.__reverse ? this.__actualWidth : 0;
+    const reverseOffsetY = this.__reverse ? this.__actualHeight : 0;
     for (const item of this.parsedComment.content) {
       if (lastFont !== getValue(item.font, this.parsedComment.font)) {
         lastFont = getValue(item.font, this.parsedComment.font);
@@ -253,12 +254,12 @@ class IrText extends IrObject {
       if (item.type === "normal") {
         const lines = normalizeNewlines(item.content).split(/\n/g);
         lines.forEach((line, index) => {
-          const posX = leftOffset - reverseOffset;
+          const posX = leftOffset - reverseOffsetX;
           const posY =
             (lineOffset + lineCount + 1) * (this.__size * config.lineHeight) +
             config.commentYPaddingTop +
             this.__size * config.lineHeight * config.commentYOffset -
-            reverseOffset;
+            reverseOffsetY;
           if (this.filter === "fuchi") {
             context.strokeText(line, posX, posY);
           }
@@ -273,12 +274,12 @@ class IrText extends IrObject {
         continue;
       }
       item.content.forEach((part, index) => {
-        const posX = leftOffset - reverseOffset;
+        const posX = leftOffset - reverseOffsetX;
         const posY =
           (lineOffset + lineCount + 1) * (this.__size * config.lineHeight) +
           config.commentYPaddingTop +
           this.__size * config.lineHeight * config.commentYOffset -
-          reverseOffset;
+          reverseOffsetY;
         switch (part.type) {
           case "fill": {
             if (this.filter === "fuchi") {


### PR DESCRIPTION
## Summary
- split reversed text draw compensation into width-based X and height-based Y offsets
- add focused regression coverage for negative size, negative scale, and non-reversed drawing

## Validation
- pnpm test src/__tests__/drawTextReverse.test.ts
- pnpm lint
- pnpm test
- pnpm build
- pre-commit hook: biome-check, check-types, test

## Review
- deep-review self-review: no actionable findings
- independent subagent review: no actionable findings

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug in reversed-text coordinate compensation inside `IrText.__draw()`: previously a single `reverseOffset` derived from `__actualWidth` was subtracted from both the X and Y drawing positions after `scale(-1, -1)`, causing incorrect vertical placement whenever text height ≠ text width. The fix splits this into `reverseOffsetX = __actualWidth` and `reverseOffsetY = __actualHeight`, aligning each axis with its correct dimension.

- `src/objects/text.ts`: replaces the shared `reverseOffset` with axis-specific `reverseOffsetX`/`reverseOffsetY` at both the `normal` and `compat` content-item draw sites.
- `src/__tests__/drawTextReverse.test.ts`: adds focused regression tests for negative-size, negative-scale, and non-reversed paths; expected coordinates are consistent with default config values (`lineHeight=1`, `commentYPaddingTop=4`, `commentYOffset=-0.2`).
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — a small, targeted correction to reversed-text drawing with matching regression tests.

The change is two-line in production code and the logic is straightforwardly correct: height should compensate the Y axis, width should compensate the X axis. The three new test cases exercise the key branches and their expected values match the formulas when default config constants are substituted.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/objects/text.ts | Splits the single reverseOffset (width-based) into separate reverseOffsetX (__actualWidth) and reverseOffsetY (__actualHeight), correctly compensating both axes after scale(-1,-1) when text is reversed. |
| src/__tests__/drawTextReverse.test.ts | New regression tests covering negative size, negative scale, and non-reversed cases; assertions verified against actual config defaults (lineHeight=1, commentYPaddingTop=4, commentYOffset=-0.2). |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["__draw() called"] --> B{__reverse?}
    B -- "false (size*scale > 0)" --> C["reverseOffsetX = 0\nreverseOffsetY = 0"]
    B -- "true (size*scale < 0)" --> D["context.scale(-1, -1)\nreverseOffsetX = __actualWidth\nreverseOffsetY = __actualHeight"]
    C --> E["posX = leftOffset - 0\nposY = formula - 0"]
    D --> F["posX = leftOffset - __actualWidth\nposY = formula - __actualHeight"]
    E --> G["fillText / strokeText at (posX, posY)"]
    F --> G
    G --> H["context.restore()"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["__draw() called"] --> B{__reverse?}
    B -- "false (size*scale > 0)" --> C["reverseOffsetX = 0\nreverseOffsetY = 0"]
    B -- "true (size*scale < 0)" --> D["context.scale(-1, -1)\nreverseOffsetX = __actualWidth\nreverseOffsetY = __actualHeight"]
    C --> E["posX = leftOffset - 0\nposY = formula - 0"]
    D --> F["posX = leftOffset - __actualWidth\nposY = formula - __actualHeight"]
    E --> G["fillText / strokeText at (posX, posY)"]
    F --> G
    G --> H["context.restore()"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix reversed text coordinate compensatio..."](https://github.com/xpadev-net/niwango.js/commit/5088c66c2eecd39da54f0dac767a60f5e5f08097) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39456568)</sub>

<!-- /greptile_comment -->