### PR TITLE
Validate public Comment inputs

### DIFF
--- a/src/__tests__/niwango.test.ts
+++ b/src/__tests__/niwango.test.ts
@@ -1,11 +1,48 @@
-import { expect, test } from "vitest";
+import { describe, expect, test } from "vitest";
 
 import type { Comment } from "@/@types/comment";
+import { comments } from "@/context";
 import Niwango from "@/main";
 import { run } from "@/testUtils";
 
+type CommentBoundary = (commentInputs: unknown[]) => void;
+
+const createComment = (overrides: Partial<Comment> = {}): Comment => ({
+  message: "hello",
+  vpos: 0,
+  isYourPost: false,
+  mail: "",
+  fromButton: false,
+  isPremium: false,
+  color: 0xffffff,
+  size: 25,
+  no: 1,
+  _vpos: 0,
+  _owner: false,
+  ...overrides,
+});
+
 const createNiwango = () => {
   return new Niwango(document.createElement("div"), [] satisfies Comment[]);
+};
+
+const useConstructorBoundary: CommentBoundary = (commentInputs) => {
+  new Niwango(document.createElement("div"), commentInputs as Comment[]);
+};
+
+const useAddCommentsBoundary: CommentBoundary = (commentInputs) => {
+  const niwango = createNiwango();
+  niwango.addComments(...(commentInputs as Comment[]));
+};
+
+const expectBoundaryToSkipOnlyInvalid = (
+  useBoundary: CommentBoundary,
+  invalidInputs: unknown[],
+) => {
+  const validComment = createComment({ no: 99, _vpos: 1, vpos: 1 });
+
+  expect(() => useBoundary([validComment, ...invalidInputs])).not.toThrow();
+  expect(comments).toEqual([validComment]);
 };
 
 test("rand", () => {
@@ -59,4 +96,49 @@ test("draw limits forward seeks from the current vpos", () => {
   expect(niwango.draw(10)).toBe(true);
   expect(niwango.draw(100_011)).toBe(false);
   expect(niwango.draw(100_012)).toBe(true);
+});
+
+test("constructor treats non-array comments input as empty", () => {
+  expect(
+    () =>
+      new Niwango(document.createElement("div"), null as unknown as Comment[]),
+  ).not.toThrow();
+  expect(comments).toEqual([]);
+});
+
+describe.each([
+  ["constructor", useConstructorBoundary],
+  ["addComments", useAddCommentsBoundary],
+])("%s comment input validation", (_boundaryName, useBoundary) => {
+  test("skips invalid messages and falsy objects", () => {
+    expectBoundaryToSkipOnlyInvalid(useBoundary, [
+      null,
+      undefined,
+      false,
+      0,
+      "",
+      [],
+      { ...createComment(), message: 1 },
+      { ...createComment(), message: null },
+    ]);
+  });
+
+  test("skips comments with non-finite numeric fields", () => {
+    expectBoundaryToSkipOnlyInvalid(useBoundary, [
+      { ...createComment(), vpos: Number.NaN },
+      { ...createComment(), color: Number.POSITIVE_INFINITY },
+      { ...createComment(), size: Number.NEGATIVE_INFINITY },
+      { ...createComment(), no: Number.NaN },
+      { ...createComment(), _vpos: Number.POSITIVE_INFINITY },
+    ]);
+  });
+
+  test("skips comments with invalid boolean flags", () => {
+    expectBoundaryToSkipOnlyInvalid(useBoundary, [
+      { ...createComment(), isYourPost: 0 },
+      { ...createComment(), fromButton: "false" },
+      { ...createComment(), isPremium: null },
+      { ...createComment(), _owner: 1 },
+    ]);
+  });
 });

--- a/src/__tests__/niwango.test.ts
+++ b/src/__tests__/niwango.test.ts
@@ -43,6 +43,7 @@ const expectBoundaryToSkipOnlyInvalid = (
 
   expect(() => useBoundary([validComment, ...invalidInputs])).not.toThrow();
   expect(comments).toEqual([validComment]);
+  expect(comments[0]).toBe(validComment);
 };
 
 test("rand", () => {

--- a/src/__tests__/niwango.test.ts
+++ b/src/__tests__/niwango.test.ts
@@ -120,6 +120,8 @@ describe.each([
       [],
       { ...createComment(), message: 1 },
       { ...createComment(), message: null },
+      { ...createComment(), mail: 1 },
+      { ...createComment(), mail: null },
     ]);
   });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,6 +27,7 @@ import {
 import { config, initConfig } from "@/definition/config";
 import { CanvasRender } from "@/render/canvas";
 import { DomRender } from "@/render/dom";
+import { normalizeComment } from "@/typeGuard";
 import { setup } from "@/utils/setup";
 import { nativeSort } from "@/utils/sort";
 
@@ -47,6 +48,34 @@ const canProcessDrawStepWindow = (fromVpos: number, toVpos: number) => {
   return stepWindow <= MAX_DRAW_VPOS_STEP_WINDOW;
 };
 
+const normalizeComments = (commentInputs: unknown) => {
+  const normalizedComments: Comment[] = [];
+  if (!Array.isArray(commentInputs)) {
+    return normalizedComments;
+  }
+  for (const commentInput of commentInputs) {
+    const comment = normalizeComment(commentInput);
+    if (comment) {
+      normalizedComments.push(comment);
+    }
+  }
+  return normalizedComments;
+};
+
+const addCommentScript = (comment: Comment) => {
+  if (comment.message.match(/^\//) && comment._owner) {
+    try {
+      const ast = {
+        ...Core.parseScript(comment.message, `${comment.no}.niwascript`),
+        __name: `${comment.no}.niwascript`,
+      };
+      addScript(ast, comment._vpos);
+    } catch (e) {
+      console.error(e);
+    }
+  }
+};
+
 class Niwango {
   private readonly render: IRender;
   static default = Niwango;
@@ -64,20 +93,9 @@ class Niwango {
     }
     this.lastVpos = -1;
 
-    comments.forEach((comment) => {
-      if (comment.message.match(/^\//) && comment._owner) {
-        try {
-          const ast = {
-            ...Core.parseScript(comment.message, `${comment.no}.niwascript`),
-            __name: `${comment.no}.niwascript`,
-          };
-          addScript(ast, comment._vpos);
-        } catch (e) {
-          console.error(e);
-        }
-      }
-    });
-    setComments(comments);
+    const normalizedComments = normalizeComments(comments);
+    normalizedComments.forEach(addCommentScript);
+    setComments(normalizedComments);
     setCurrentTime(-1);
     setRender(this.render);
     setGlobalScope({});
@@ -184,20 +202,9 @@ class Niwango {
   }
 
   public addComments(...newComments: Comment[]) {
-    newComments.forEach((comment) => {
-      if (comment.message.match(/^\//) && comment._owner) {
-        try {
-          const ast = {
-            ...Core.parseScript(comment.message, `${comment.no}.niwascript`),
-            __name: `${comment.no}.niwascript`,
-          };
-          addScript(ast, comment._vpos);
-        } catch (e) {
-          console.error(e);
-        }
-      }
-    });
-    setComments([...comments, ...newComments]);
+    const normalizedComments = normalizeComments(newComments);
+    normalizedComments.forEach(addCommentScript);
+    setComments([...comments, ...normalizedComments]);
   }
 }
 

--- a/src/typeGuard.ts
+++ b/src/typeGuard.ts
@@ -50,30 +50,69 @@ const shapeOptionTypes = {
   PrimitiveTypeName
 >;
 
-const typeGuard = {
-  comment: (i: unknown): i is Comment =>
-    objectVerify(i, [
-      "message",
-      "vpos",
-      "isYourPost",
-      "mail",
-      "fromButton",
-      "isPremium",
-      "color",
-      "size",
-      "no",
-      "_vpos",
-      "_owner",
-    ]),
-  IrTextLiteral: (i: unknown): i is ITextLiteral =>
-    isLiteralObject(i, "IrText") && objectHasTypes(i.options, textOptionTypes),
-  IrShapeLiteral: (i: unknown): i is IShapeLiteral =>
-    isLiteralObject(i, "IrShape") &&
-    objectHasTypes(i.options, shapeOptionTypes),
-};
-
 const isRecord = (item: unknown): item is RecordValue =>
   typeof item === "object" && item !== null && !Array.isArray(item);
+
+const normalizeComment = (item: unknown): Comment | null => {
+  try {
+    if (!isRecord(item)) {
+      return null;
+    }
+    const {
+      message,
+      vpos,
+      isYourPost,
+      mail,
+      fromButton,
+      isPremium,
+      color,
+      size,
+      no,
+      _vpos,
+      _owner,
+    } = item;
+    if (typeof message !== "string" || typeof mail !== "string") {
+      return null;
+    }
+    if (
+      typeof vpos !== "number" ||
+      !Number.isFinite(vpos) ||
+      typeof color !== "number" ||
+      !Number.isFinite(color) ||
+      typeof size !== "number" ||
+      !Number.isFinite(size) ||
+      typeof no !== "number" ||
+      !Number.isFinite(no) ||
+      typeof _vpos !== "number" ||
+      !Number.isFinite(_vpos)
+    ) {
+      return null;
+    }
+    if (
+      typeof isYourPost !== "boolean" ||
+      typeof fromButton !== "boolean" ||
+      typeof isPremium !== "boolean" ||
+      typeof _owner !== "boolean"
+    ) {
+      return null;
+    }
+    return {
+      message,
+      vpos,
+      isYourPost,
+      mail,
+      fromButton,
+      isPremium,
+      color,
+      size,
+      no,
+      _vpos,
+      _owner,
+    };
+  } catch (_e) {
+    return null;
+  }
+};
 
 const isLiteralObject = (
   item: unknown,
@@ -112,15 +151,15 @@ const objectHasTypes = (
   return true;
 };
 
-const objectVerify = (item: unknown, keys: string[]): boolean => {
-  if (typeof item !== "object" || !item) {
-    return false;
-  }
-  for (const key of keys) {
-    if (!Object.prototype.hasOwnProperty.call(item, key)) {
-      return false;
-    }
-  }
-  return true;
+const typeGuard = {
+  comment: (i: unknown): i is Comment => normalizeComment(i) !== null,
+  normalizeComment,
+  IrTextLiteral: (i: unknown): i is ITextLiteral =>
+    isLiteralObject(i, "IrText") && objectHasTypes(i.options, textOptionTypes),
+  IrShapeLiteral: (i: unknown): i is IShapeLiteral =>
+    isLiteralObject(i, "IrShape") &&
+    objectHasTypes(i.options, shapeOptionTypes),
 };
+
+export { normalizeComment };
 export default typeGuard;

--- a/src/typeGuard.ts
+++ b/src/typeGuard.ts
@@ -96,19 +96,7 @@ const normalizeComment = (item: unknown): Comment | null => {
     ) {
       return null;
     }
-    return {
-      message,
-      vpos,
-      isYourPost,
-      mail,
-      fromButton,
-      isPremium,
-      color,
-      size,
-      no,
-      _vpos,
-      _owner,
-    };
+    return item as unknown as Comment;
   } catch (_e) {
     return null;
   }

--- a/src/typeGuard.ts
+++ b/src/typeGuard.ts
@@ -153,7 +153,6 @@ const objectHasTypes = (
 
 const typeGuard = {
   comment: (i: unknown): i is Comment => normalizeComment(i) !== null,
-  normalizeComment,
   IrTextLiteral: (i: unknown): i is ITextLiteral =>
     isLiteralObject(i, "IrText") && objectHasTypes(i.options, textOptionTypes),
   IrShapeLiteral: (i: unknown): i is IShapeLiteral =>


### PR DESCRIPTION
## Summary
- add runtime normalization for public Comment values before constructor/addComments storage
- skip malformed Comment entries before script parsing or comment queueing
- cover constructor and addComments boundaries for invalid messages, falsy/non-object values, non-finite numbers, and invalid booleans

## Validation
- pnpm test
- pnpm lint
- pnpm build

## Review
- deep-review self pass completed locally
- independent subagent review completed with no actionable findings

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds runtime input validation at the `Niwango` constructor and `addComments` public API boundaries by introducing `normalizeComment` (a typed null-returning validator) and a `normalizeComments` helper that filters out malformed entries before they reach the script-parsing or comment-storage logic.

- **`src/typeGuard.ts`**: Replaces the weaker `objectVerify` (key-presence only) with `normalizeComment`, which validates the type and finiteness of every `Comment` field. `typeGuard.comment` now delegates to it, and `normalizeComment` is exported as a named export only (not duplicated onto the `typeGuard` object).
- **`src/main.ts`**: Extracts the duplicated owner-script registration logic into a shared `addCommentScript` helper and wraps both the constructor and `addComments` with `normalizeComments`, gracefully handling non-array inputs and malformed entries.
- **`src/__tests__/niwango.test.ts`**: Adds parameterised tests covering both entry points for null/falsy values, non-finite numeric fields, invalid boolean flags, invalid `message`/`mail` strings, and non-array constructor input.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change adds defensive validation at two public API boundaries without altering any existing happy-path behavior.

All three changed files are internally consistent. The new `normalizeComment` correctly validates every required `Comment` field (type, finiteness, and boolean strictness). The `normalizeComments` helper handles the non-array constructor case and silently drops malformed entries before they reach script parsing or storage. Deduplication of the owner-script logic into `addCommentScript` removes a copy-paste risk. Tests cover both entry points parametrically across null/falsy, non-finite, and invalid-boolean dimensions, and the `mail` coverage gap noted in the prior review round has been addressed.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/typeGuard.ts | Replaces `objectVerify` with `normalizeComment` (validates all 11 Comment fields by type and finiteness); `typeGuard.comment` now delegates to it; `normalizeComment` is a named export only, not duplicated on the object. |
| src/main.ts | Adds `normalizeComments` and `addCommentScript` helpers; constructor and `addComments` now filter inputs through `normalizeComments`, handling non-array inputs and malformed entries gracefully. |
| src/__tests__/niwango.test.ts | Adds parameterised boundary tests for constructor and addComments covering null/falsy, non-finite numerics, invalid booleans, and invalid string fields; `mail` validation now covered (addressing prior review comment). |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Public input\n(constructor / addComments)"] --> B{Array.isArray?}
    B -- No --> C["Return []"]
    B -- Yes --> D["Iterate elements"]
    D --> E["normalizeComment(item)"]
    E --> F{isRecord?}
    F -- No --> G["return null\n(skip)"]
    F -- Yes --> H{string fields\nmessage, mail?}
    H -- fail --> G
    H -- pass --> I{finite number\nfields\nvpos, color, size, no, _vpos?}
    I -- fail --> G
    I -- pass --> J{boolean\nfields\nisYourPost, fromButton,\nisPremium, _owner?}
    J -- fail --> G
    J -- pass --> K["return item as Comment"]
    K --> L["addCommentScript\n(owner /command parse)"]
    L --> M["setComments / push to store"]
    G --> D
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["Public input\n(constructor / addComments)"] --> B{Array.isArray?}
    B -- No --> C["Return []"]
    B -- Yes --> D["Iterate elements"]
    D --> E["normalizeComment(item)"]
    E --> F{isRecord?}
    F -- No --> G["return null\n(skip)"]
    F -- Yes --> H{string fields\nmessage, mail?}
    H -- fail --> G
    H -- pass --> I{finite number\nfields\nvpos, color, size, no, _vpos?}
    I -- fail --> G
    I -- pass --> J{boolean\nfields\nisYourPost, fromButton,\nisPremium, _owner?}
    J -- fail --> G
    J -- pass --> K["return item as Comment"]
    K --> L["addCommentScript\n(owner /command parse)"]
    L --> M["setComments / push to store"]
    G --> D
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["Preserve valid comment instances"](https://github.com/xpadev-net/niwango.js/commit/18a3f71f322348bef7c615fe88eab3e2f330405e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39456846)</sub>

<!-- /greptile_comment -->