### PR TITLE
Validate IrText and IrShape option schemas

### DIFF
--- a/src/@types/IrShape.d.ts
+++ b/src/@types/IrShape.d.ts
@@ -1,7 +1,7 @@
 import { IObjectOptions } from "@/@types/IrObject";
 
-type IShapeType = "circle" | "rect";
-type IShapeOptions = {
+export type IShapeType = "circle" | "rect";
+export type IShapeOptions = {
   shape: IShapeType;
   width: number;
   height: number;

--- a/src/@types/IrText.d.ts
+++ b/src/@types/IrText.d.ts
@@ -23,8 +23,8 @@ export type commentContentIndex = {
 };
 export type commentFont = "defont" | "gulim" | "simsun";
 
-type ITextFilter = "" | "fuchi" | "kasumi" | "kage";
-type ITextOptions = {
+export type ITextFilter = "" | "fuchi" | "kasumi" | "kage";
+export type ITextOptions = {
   text: string;
   size: number;
   bold: boolean;

--- a/src/__tests__/objectOptionSchema.test.ts
+++ b/src/__tests__/objectOptionSchema.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import type { IShapeOptionsNullable } from "@/@types/IrShape";
+import type { ITextOptionsNullable } from "@/@types/IrText";
+import { resetCanvas } from "@/contexts/canvas";
+import { initConfig } from "@/definition/config";
+import { IrShape } from "@/objects/shape";
+import { IrText } from "@/objects/text";
+
+const createMockContext = () =>
+  ({
+    beginPath: vi.fn(),
+    clearRect: vi.fn(),
+    drawImage: vi.fn(),
+    ellipse: vi.fn(),
+    fill: vi.fn(),
+    fillRect: vi.fn(),
+    fillText: vi.fn(),
+    measureText: vi.fn((text: string) => ({ width: text.length * 10 })),
+    restore: vi.fn(),
+    save: vi.fn(),
+    scale: vi.fn(),
+    strokeRect: vi.fn(),
+    strokeText: vi.fn(),
+  }) as unknown as CanvasRenderingContext2D;
+
+describe("IrText option schema normalization", () => {
+  beforeEach(() => {
+    initConfig();
+    resetCanvas();
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockImplementation(() =>
+      createMockContext(),
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    resetCanvas();
+  });
+
+  test("falls back to defaults for non-finite numeric options", () => {
+    const text = new IrText({
+      alpha: Number.POSITIVE_INFINITY,
+      scale: Number.NEGATIVE_INFINITY,
+      size: Number.NaN,
+      text: "text",
+    });
+
+    expect(text.alpha).toBe(0);
+    expect(text.scale).toBe(1);
+    expect(text.size).toBe(14);
+  });
+
+  test("falls back to defaults for strings outside declared unions", () => {
+    const text = new IrText({
+      filter: "outline",
+      mover: "teleport",
+      text: "text",
+    } as unknown as ITextOptionsNullable);
+
+    expect(text.filter).toBe("");
+    expect(text.mover).toBe("");
+  });
+
+  test("normalizes invalid assigned option values", () => {
+    const text = new IrText({ text: "text" });
+
+    text.alpha = Number.POSITIVE_INFINITY;
+    text.color = Number.NaN;
+    text.filter = "outline" as never;
+    text.mover = "teleport" as never;
+    text.size = Number.NaN;
+    text.x = Number.POSITIVE_INFINITY;
+    text.y = Number.NEGATIVE_INFINITY;
+    text.z = Number.NaN;
+
+    expect(text.alpha).toBe(0);
+    expect(text.color).toBe(16777215);
+    expect(text.filter).toBe("");
+    expect(text.mover).toBe("");
+    expect(text.size).toBe(14);
+    expect(text.x).toBe(0);
+    expect(text.y).toBe(0);
+    expect(text.z).toBe(0);
+  });
+});
+
+describe("IrShape option schema normalization", () => {
+  beforeEach(() => {
+    initConfig();
+    resetCanvas();
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockImplementation(() =>
+      createMockContext(),
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    resetCanvas();
+  });
+
+  test("falls back to defaults for non-finite numeric options", () => {
+    const shape = new IrShape({
+      alpha: Number.NEGATIVE_INFINITY,
+      height: Number.POSITIVE_INFINITY,
+      rotation: Number.NaN,
+      width: Number.NaN,
+    });
+
+    expect(shape.alpha).toBe(0);
+    expect(shape.height).toBe(30);
+    expect(shape.rotation).toBe(0);
+    expect(shape.width).toBe(30);
+  });
+
+  test("falls back to defaults for strings outside declared unions", () => {
+    const shape = new IrShape({
+      mover: "teleport",
+      shape: "triangle",
+    } as unknown as IShapeOptionsNullable);
+
+    expect(shape.mover).toBe("");
+    expect(shape.shape).toBe("circle");
+  });
+
+  test("normalizes invalid assigned option values", () => {
+    const shape = new IrShape({});
+
+    shape.alpha = Number.POSITIVE_INFINITY;
+    shape.color = Number.NaN;
+    shape.height = Number.NEGATIVE_INFINITY;
+    shape.mover = "teleport" as never;
+    shape.rotation = Number.NaN;
+    shape.scale = Number.POSITIVE_INFINITY;
+    shape.shape = "triangle" as never;
+    shape.width = Number.NaN;
+    shape.x = Number.POSITIVE_INFINITY;
+    shape.y = Number.NEGATIVE_INFINITY;
+    shape.z = Number.NaN;
+
+    expect(shape.alpha).toBe(0);
+    expect(shape.color).toBe(16777215);
+    expect(shape.height).toBe(30);
+    expect(shape.mover).toBe("");
+    expect(shape.rotation).toBe(0);
+    expect(shape.scale).toBe(1);
+    expect(shape.shape).toBe("circle");
+    expect(shape.width).toBe(30);
+    expect(shape.x).toBe(0);
+    expect(shape.y).toBe(0);
+    expect(shape.z).toBe(0);
+  });
+});

--- a/src/objects/options.ts
+++ b/src/objects/options.ts
@@ -1,0 +1,13 @@
+import type { IObjectMover } from "@/@types/IrObject";
+
+const objectMoverOptionMap = {
+  "": true,
+  hopping: true,
+  rolling: true,
+  simple: true,
+  smooth: true,
+} as const satisfies Record<IObjectMover, true>;
+
+const objectMoverOptions = Object.keys(objectMoverOptionMap) as IObjectMover[];
+
+export { objectMoverOptions };

--- a/src/objects/shape.ts
+++ b/src/objects/shape.ts
@@ -4,6 +4,7 @@ import type { KTMap } from "@/@types/types";
 import { render } from "@/context";
 import { getCanvas } from "@/contexts/canvas";
 import { IrObject } from "@/objects/object";
+import { objectMoverOptions } from "@/objects/options";
 import { number2color } from "@/utils/number2color";
 import { getOptions } from "@/utils/object";
 import {
@@ -67,12 +68,16 @@ const finiteNumberOptionKeys = [
 ] as const satisfies readonly (keyof IShapeOptions)[];
 
 const shapeOptions = ["circle", "rect"] as const;
-const moverOptions = ["", "smooth", "simple", "rolling", "hopping"] as const;
 
 const normalizeOptions = (options: IShapeOptionsNullable) => {
   normalizeFiniteNumbers(options, defaultOptions, finiteNumberOptionKeys);
   normalizeStringUnion(options, "shape", shapeOptions, defaultOptions.shape);
-  normalizeStringUnion(options, "mover", moverOptions, defaultOptions.mover);
+  normalizeStringUnion(
+    options,
+    "mover",
+    objectMoverOptions,
+    defaultOptions.mover,
+  );
   return options;
 };
 
@@ -227,7 +232,11 @@ class IrShape extends IrObject {
   }
 
   override set mover(val: IObjectMover) {
-    super.mover = getAllowedString(val, moverOptions, defaultOptions.mover);
+    super.mover = getAllowedString(
+      val,
+      objectMoverOptions,
+      defaultOptions.mover,
+    );
   }
 
   override __updateColor() {

--- a/src/objects/shape.ts
+++ b/src/objects/shape.ts
@@ -1,3 +1,4 @@
+import type { IObjectMover } from "@/@types/IrObject";
 import type { IShapeOptions, IShapeOptionsNullable } from "@/@types/IrShape";
 import type { KTMap } from "@/@types/types";
 import { render } from "@/context";
@@ -5,7 +6,13 @@ import { getCanvas } from "@/contexts/canvas";
 import { IrObject } from "@/objects/object";
 import { number2color } from "@/utils/number2color";
 import { getOptions } from "@/utils/object";
-import { format } from "@/utils/utils";
+import {
+  format,
+  getAllowedString,
+  getFiniteNumber,
+  normalizeFiniteNumbers,
+  normalizeStringUnion,
+} from "@/utils/utils";
 
 const optionTypes: KTMap<keyof IShapeOptions> = {
   x: "number",
@@ -47,6 +54,28 @@ const defaultOptions: IShapeOptions = {
   mover: "",
 };
 
+const finiteNumberOptionKeys = [
+  "x",
+  "y",
+  "z",
+  "width",
+  "height",
+  "color",
+  "scale",
+  "alpha",
+  "rotation",
+] as const satisfies readonly (keyof IShapeOptions)[];
+
+const shapeOptions = ["circle", "rect"] as const;
+const moverOptions = ["", "smooth", "simple", "rolling", "hopping"] as const;
+
+const normalizeOptions = (options: IShapeOptionsNullable) => {
+  normalizeFiniteNumbers(options, defaultOptions, finiteNumberOptionKeys);
+  normalizeStringUnion(options, "shape", shapeOptions, defaultOptions.shape);
+  normalizeStringUnion(options, "mover", moverOptions, defaultOptions.mover);
+  return options;
+};
+
 const assertMaskSupported = (mask: unknown) => {
   if (mask === true) {
     throw new Error("drawShape mask option is not supported");
@@ -60,7 +89,7 @@ class IrShape extends IrObject {
   override options: IShapeOptions;
   public override readonly __type: string = "IrShape";
   constructor(_options: IShapeOptionsNullable) {
-    const options = format(_options, optionTypes);
+    const options = normalizeOptions(format(_options, optionTypes));
     assertMaskSupported(options.mask);
     super(options);
     this.options = getOptions(defaultOptions, options);
@@ -70,12 +99,40 @@ class IrShape extends IrObject {
     this.__draw();
   }
 
+  override get x() {
+    return super.x;
+  }
+
+  override set x(val: number) {
+    super.x = getFiniteNumber(val, defaultOptions.x);
+  }
+
+  override get y() {
+    return super.y;
+  }
+
+  override set y(val: number) {
+    super.y = getFiniteNumber(val, defaultOptions.y);
+  }
+
+  override get z() {
+    return super.z;
+  }
+
+  override set z(val: number) {
+    super.z = getFiniteNumber(val, defaultOptions.z);
+  }
+
   get shape() {
     return this.options.shape;
   }
 
   set shape(val) {
-    this.options.shape = val;
+    this.options.shape = getAllowedString(
+      val,
+      shapeOptions,
+      defaultOptions.shape,
+    );
     this.__modified = true;
   }
 
@@ -84,8 +141,9 @@ class IrShape extends IrObject {
   }
 
   override set width(val) {
-    this.options.width = val;
-    this.__width = val;
+    const value = getFiniteNumber(val, defaultOptions.width);
+    this.options.width = value;
+    this.__width = value;
     this.__modified = true;
   }
 
@@ -94,8 +152,9 @@ class IrShape extends IrObject {
   }
 
   override set height(val) {
-    this.options.height = val;
-    this.__height = val;
+    const value = getFiniteNumber(val, defaultOptions.height);
+    this.options.height = value;
+    this.__height = value;
     this.__modified = true;
   }
 
@@ -109,6 +168,22 @@ class IrShape extends IrObject {
 
   protected override get __commentmask(): boolean {
     return this.options.commentmask;
+  }
+
+  override get scale() {
+    return super.scale;
+  }
+
+  override set scale(val: number) {
+    super.scale = getFiniteNumber(val, defaultOptions.scale);
+  }
+
+  override get color() {
+    return super.color;
+  }
+
+  override set color(val: number) {
+    super.color = getFiniteNumber(val, defaultOptions.color);
   }
 
   get mask() {
@@ -133,7 +208,26 @@ class IrShape extends IrObject {
   }
 
   set rotation(val) {
-    this.options.rotation = val;
+    this.options.rotation = getFiniteNumber(val, defaultOptions.rotation);
+  }
+
+  override get alpha() {
+    return super.alpha;
+  }
+
+  override set alpha(val: unknown) {
+    super.alpha = getFiniteNumber(
+      typeof val === "number" ? val : Number(val),
+      defaultOptions.alpha,
+    );
+  }
+
+  override get mover() {
+    return super.mover;
+  }
+
+  override set mover(val: IObjectMover) {
+    super.mover = getAllowedString(val, moverOptions, defaultOptions.mover);
   }
 
   override __updateColor() {

--- a/src/objects/text.ts
+++ b/src/objects/text.ts
@@ -1,4 +1,5 @@
 import type { parsedComment } from "@/@types/flashText";
+import type { IObjectMover } from "@/@types/IrObject";
 import type { ITextOptions, ITextOptionsNullable } from "@/@types/IrText";
 import type { KTMap } from "@/@types/types";
 import { render } from "@/context";
@@ -8,7 +9,15 @@ import { IrObject } from "@/objects/object";
 import { measure, normalizeNewlines, parse } from "@/utils/flashText";
 import { number2color } from "@/utils/number2color";
 import { getOptions } from "@/utils/object";
-import { format, getValue, parseFont } from "@/utils/utils";
+import {
+  format,
+  getAllowedString,
+  getFiniteNumber,
+  getValue,
+  normalizeFiniteNumbers,
+  normalizeStringUnion,
+  parseFont,
+} from "@/utils/utils";
 
 const optionTypes: KTMap<keyof ITextOptions> = {
   text: "string",
@@ -46,6 +55,26 @@ const defaultOptions: ITextOptions = {
   mover: "",
 };
 
+const finiteNumberOptionKeys = [
+  "x",
+  "y",
+  "z",
+  "size",
+  "color",
+  "scale",
+  "alpha",
+] as const satisfies readonly (keyof ITextOptions)[];
+
+const filterOptions = ["", "fuchi", "kasumi", "kage"] as const;
+const moverOptions = ["", "smooth", "simple", "rolling", "hopping"] as const;
+
+const normalizeOptions = (options: ITextOptionsNullable) => {
+  normalizeFiniteNumbers(options, defaultOptions, finiteNumberOptionKeys);
+  normalizeStringUnion(options, "filter", filterOptions, defaultOptions.filter);
+  normalizeStringUnion(options, "mover", moverOptions, defaultOptions.mover);
+  return options;
+};
+
 /**
  * テキストオブジェクトのクラス
  */
@@ -59,7 +88,7 @@ class IrText extends IrObject {
   private __reverse: boolean;
   public override readonly __type: string = "IrText";
   constructor(_options: ITextOptionsNullable) {
-    const options = format(_options, optionTypes);
+    const options = normalizeOptions(format(_options, optionTypes));
     super(options);
     this.options = getOptions(defaultOptions, options);
     this.__actualHeight = this.__actualWidth = 0;
@@ -88,26 +117,51 @@ class IrText extends IrObject {
     return this.__actualHeight * this.__scale;
   }
 
+  override get x() {
+    return super.x;
+  }
+
+  override set x(val: number) {
+    super.x = getFiniteNumber(val, defaultOptions.x);
+  }
+
+  override get y() {
+    return super.y;
+  }
+
+  override set y(val: number) {
+    super.y = getFiniteNumber(val, defaultOptions.y);
+  }
+
+  override get z() {
+    return super.z;
+  }
+
+  override set z(val: number) {
+    super.z = getFiniteNumber(val, defaultOptions.z);
+  }
+
   get size() {
     return this.options.size;
   }
 
   set size(val) {
-    if (this.options.size < 3 !== val < 3) {
-      this.parsedComment = parse(this.text, val < 3);
+    const value = getFiniteNumber(val, defaultOptions.size);
+    if (this.options.size < 3 !== value < 3) {
+      this.parsedComment = parse(this.text, value < 3);
     }
-    const size = Math.abs(val * this.options.scale);
+    const size = Math.abs(value * this.options.scale);
     if (size < 10) {
       this.__scale = Math.max(size / 10, 0.16);
       this.__size = 10;
-    } else if (size > 100 && val >= 3) {
+    } else if (size > 100 && value >= 3) {
       this.__scale = size / 100;
       this.__size = 100;
     } else {
       this.__scale = 1;
       this.__size = size;
     }
-    this.options.size = val;
+    this.options.size = value;
     this.__updateFont();
     this.__modified = true;
   }
@@ -136,8 +190,9 @@ class IrText extends IrObject {
   }
 
   override set scale(val: number) {
-    const size = Math.abs(val * this.options.size);
-    this.__reverse = val < 0;
+    const value = getFiniteNumber(val, defaultOptions.scale);
+    const size = Math.abs(value * this.options.size);
+    this.__reverse = value < 0;
     if (size < 10) {
       this.__scale = Math.max(size / 10, 0.16);
       this.__size = 10;
@@ -148,7 +203,7 @@ class IrText extends IrObject {
       this.__scale = 1;
       this.__size = size;
     }
-    this.options.scale = val;
+    this.options.scale = value;
     this.__updateFont();
     this.__modified = true;
   }
@@ -163,13 +218,44 @@ class IrText extends IrObject {
     this.__modified = true;
   }
 
+  override get color() {
+    return super.color;
+  }
+
+  override set color(val: number) {
+    super.color = getFiniteNumber(val, defaultOptions.color);
+  }
+
   get filter() {
     return this.options.filter;
   }
 
   set filter(val) {
-    this.options.filter = val;
+    this.options.filter = getAllowedString(
+      val,
+      filterOptions,
+      defaultOptions.filter,
+    );
     this.__modified = true;
+  }
+
+  override get alpha() {
+    return super.alpha;
+  }
+
+  override set alpha(val: unknown) {
+    super.alpha = getFiniteNumber(
+      typeof val === "number" ? val : Number(val),
+      defaultOptions.alpha,
+    );
+  }
+
+  override get mover() {
+    return super.mover;
+  }
+
+  override set mover(val: IObjectMover) {
+    super.mover = getAllowedString(val, moverOptions, defaultOptions.mover);
   }
 
   __updateFont() {

--- a/src/objects/text.ts
+++ b/src/objects/text.ts
@@ -6,6 +6,7 @@ import { render } from "@/context";
 import { getCanvas } from "@/contexts/canvas";
 import { config } from "@/definition/config";
 import { IrObject } from "@/objects/object";
+import { objectMoverOptions } from "@/objects/options";
 import { measure, normalizeNewlines, parse } from "@/utils/flashText";
 import { number2color } from "@/utils/number2color";
 import { getOptions } from "@/utils/object";
@@ -66,12 +67,16 @@ const finiteNumberOptionKeys = [
 ] as const satisfies readonly (keyof ITextOptions)[];
 
 const filterOptions = ["", "fuchi", "kasumi", "kage"] as const;
-const moverOptions = ["", "smooth", "simple", "rolling", "hopping"] as const;
 
 const normalizeOptions = (options: ITextOptionsNullable) => {
   normalizeFiniteNumbers(options, defaultOptions, finiteNumberOptionKeys);
   normalizeStringUnion(options, "filter", filterOptions, defaultOptions.filter);
-  normalizeStringUnion(options, "mover", moverOptions, defaultOptions.mover);
+  normalizeStringUnion(
+    options,
+    "mover",
+    objectMoverOptions,
+    defaultOptions.mover,
+  );
   return options;
 };
 
@@ -255,7 +260,11 @@ class IrText extends IrObject {
   }
 
   override set mover(val: IObjectMover) {
-    super.mover = getAllowedString(val, moverOptions, defaultOptions.mover);
+    super.mover = getAllowedString(
+      val,
+      objectMoverOptions,
+      defaultOptions.mover,
+    );
   }
 
   __updateFont() {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -90,25 +90,87 @@ const getValue = <T>(value: T | undefined, fallback: T): T => {
   return value ?? fallback;
 };
 
-const format = (
-  options: { [key: string]: unknown },
+const format = <T extends object>(
+  options: T,
   types: { [key: string]: ValueType },
 ) => {
+  const objectOptions = options as { [key: string]: unknown };
   for (const key of Object.keys(options)) {
-    const value = options[key];
+    const value = objectOptions[key];
     const type = types[key];
     if (!type || type === "any") continue;
     if (value !== undefined && typeof value !== type) {
       if (type === "string") {
-        options[key] = Core.format(value, "string");
+        objectOptions[key] = Core.format(value, "string");
       } else if (type === "number") {
-        options[key] = Core.format(value, "number");
+        objectOptions[key] = Core.format(value, "number");
       } else if (type === "boolean") {
-        options[key] = Core.format(value, "boolean");
+        objectOptions[key] = Core.format(value, "boolean");
       }
     }
   }
   return options;
 };
 
-export { format, getGlobalScope, getValue, parseFont };
+const getFiniteNumber = (
+  value: number | undefined,
+  fallback: number,
+): number => {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+};
+
+const getAllowedString = <T extends string>(
+  value: string | undefined,
+  allowedValues: readonly T[],
+  fallback: T,
+): T => {
+  return allowedValues.includes(value as T) ? (value as T) : fallback;
+};
+
+const normalizeFiniteNumbers = <T extends object>(
+  options: Partial<T>,
+  defaults: T,
+  keys: readonly (keyof T)[],
+): Partial<T> => {
+  for (const key of keys) {
+    const value = options[key];
+    if (
+      value !== undefined &&
+      (typeof value !== "number" || !Number.isFinite(value))
+    ) {
+      options[key] = defaults[key];
+    }
+  }
+  return options;
+};
+
+const normalizeStringUnion = <
+  T extends object,
+  K extends keyof T,
+  V extends Extract<T[K], string>,
+>(
+  options: Partial<T>,
+  key: K,
+  allowedValues: readonly V[],
+  fallback: V,
+): Partial<T> => {
+  const value = options[key];
+  if (
+    value !== undefined &&
+    (typeof value !== "string" || !allowedValues.includes(value as V))
+  ) {
+    options[key] = fallback as T[K];
+  }
+  return options;
+};
+
+export {
+  format,
+  getAllowedString,
+  getFiniteNumber,
+  getGlobalScope,
+  getValue,
+  normalizeFiniteNumbers,
+  normalizeStringUnion,
+  parseFont,
+};


### PR DESCRIPTION
## Summary
- normalize IrText/IrShape finite numeric options to existing defaults when NaN/Infinity is provided
- normalize filter/shape/mover union strings to declared default values
- export public option/union d.ts names and add regression coverage for constructor and assignment paths

## Validation
- pnpm lint
- pnpm test
- pnpm build
- pre-commit hook: biome-check, check-types, test

## Review
- deep-review checklist pass focused on boundary/type/schema contracts
- independent subagent review repeated until no actionable issues remained

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds schema validation to `IrText` and `IrShape` option fields, normalizing NaN/Infinity numeric inputs to declared defaults and rejecting out-of-union string values (filter, shape, mover) at both construction time and on each property setter assignment.

- **`src/utils/utils.ts`**: Four new utility functions (`getFiniteNumber`, `getAllowedString`, `normalizeFiniteNumbers`, `normalizeStringUnion`) handle validation in a reusable, type-safe way; `format()` is made generic to preserve the input type.
- **`src/objects/options.ts`**: `objectMoverOptions` is centralized using a `satisfies Record<IObjectMover, true>` constraint, ensuring compile-time exhaustiveness and replacing the previously duplicated arrays in `shape.ts` and `text.ts`.
- **`src/objects/shape.ts` / `src/objects/text.ts`**: A `normalizeOptions` pass is inserted after `format()` in the constructor, and every relevant setter is overridden with the corresponding guard; getter+setter pairs are both overridden throughout to satisfy JavaScript accessor inheritance rules.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is purely additive validation with no observable regressions on valid inputs.

Every code path touched is a guard that only changes behavior for previously undefined inputs (NaN, ±Infinity, out-of-union strings). Valid finite numbers and declared union strings pass through unchanged. The satisfies Record<IObjectMover, true> constraint keeps the mover allow-list in sync with the type at compile time. The new test file exercises both the constructor and assignment paths for all guarded fields in both classes.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/utils/utils.ts | Adds getFiniteNumber, getAllowedString, normalizeFiniteNumbers, normalizeStringUnion helpers; makes format() generic — all implementations are correct and well-typed. |
| src/objects/options.ts | Centralizes IObjectMover allowed values using a satisfies Record constraint — resolves the duplication concern from the previous review thread. |
| src/objects/shape.ts | Adds normalizeOptions on construction and overrides every setter (x, y, z, width, height, scale, color, alpha, rotation, mover, shape) with getFiniteNumber/getAllowedString guards; getter+setter pairs are both overridden where needed. |
| src/objects/text.ts | Same pattern as shape.ts; the pre-existing override get scale() ensures the getter is not lost, and the setter is updated to use getFiniteNumber. |
| src/__tests__/objectOptionSchema.test.ts | New test file covering constructor and assignment normalization for both IrText and IrShape — exercises NaN, ±Infinity, and out-of-union string paths. |
| src/@types/IrShape.d.ts | Exports IShapeType and IShapeOptions — additive, backward-compatible change. |
| src/@types/IrText.d.ts | Exports ITextFilter and ITextOptions — additive, backward-compatible change. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["new IrShape / new IrText\n(_options: Partial)"] --> B["format(_options, optionTypes)\nCore type coercion"]
    B --> C["normalizeOptions()\nnormalizeFiniteNumbers → replace NaN/Inf with default\nnormalizeStringUnion → replace unknown union value with default"]
    C --> D["super(options)\nIrObject constructor"]

    E["setter assignment\nobj.alpha = Infinity\nobj.filter = 'teleport'"] --> F{"Numeric field?"}
    F -- yes --> G["getFiniteNumber(val, default)\n→ fallback if !isFinite"]
    F -- no --> H["getAllowedString(val, allowed, default)\n→ fallback if not in union"]
    G --> I["super.setter(validatedVal)"]
    H --> I
    I --> J["IrObject base setter\n(clamp, updateColor, modified flag …)"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["new IrShape / new IrText\n(_options: Partial)"] --> B["format(_options, optionTypes)\nCore type coercion"]
    B --> C["normalizeOptions()\nnormalizeFiniteNumbers → replace NaN/Inf with default\nnormalizeStringUnion → replace unknown union value with default"]
    C --> D["super(options)\nIrObject constructor"]

    E["setter assignment\nobj.alpha = Infinity\nobj.filter = 'teleport'"] --> F{"Numeric field?"}
    F -- yes --> G["getFiniteNumber(val, default)\n→ fallback if !isFinite"]
    F -- no --> H["getAllowedString(val, allowed, default)\n→ fallback if not in union"]
    G --> I["super.setter(validatedVal)"]
    H --> I
    I --> J["IrObject base setter\n(clamp, updateColor, modified flag …)"]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["Share IrObject mover option schema"](https://github.com/xpadev-net/niwango.js/commit/fc77a62b6de87c27ba69c363e3bc44d1b1988269) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39460371)</sub>

<!-- /greptile_comment -->