### PR TITLE
Fix public declaration package surface

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "build": "npx rimraf dist&&npm run build:ts&&npm run build:dts",
     "build:ts": "rolldown -c rolldown.config.mjs",
-    "build:dts": "npx copyfiles -u 2 src/@types/*.d.ts dist/dts/@types/&&tsc --emitDeclarationOnly&&node util/resolve-path-alias.cjs&&rolldown -c rolldown.config.dts.mjs",
+    "build:dts": "npx copyfiles -u 2 src/@types/*.d.ts dist/dts/@types/&&tsc --emitDeclarationOnly&&node util/resolve-path-alias.cjs&&rolldown -c rolldown.config.dts.mjs --input ./dist/dts/index.d.ts",
     "pegjs": "peggy --cache -o ./src/parser/parser.js --format umd --export-var parser ./src/grammer/niwango.pegjs",
     "watch": "rolldown -c rolldown.config.mjs --watch",
     "typedoc": "typedoc --entryPointStrategy Expand --out ./docs/type/ ./src/",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "build": "npx rimraf dist&&npm run build:ts&&npm run build:dts",
     "build:ts": "rolldown -c rolldown.config.mjs",
-    "build:dts": "npx copyfiles -u 2 src/@types/*.d.ts dist/dts/@types/&&tsc --emitDeclarationOnly&&node util/resolve-path-alias.cjs&&rolldown -c rolldown.config.dts.mjs --input ./dist/dts/index.d.ts",
+    "build:dts": "npx copyfiles -u 2 src/@types/*.d.ts dist/dts/@types/&&tsc --emitDeclarationOnly&&node util/resolve-path-alias.cjs&&rolldown -c rolldown.config.dts.mjs",
     "pegjs": "peggy --cache -o ./src/parser/parser.js --format umd --export-var parser ./src/grammer/niwango.pegjs",
     "watch": "rolldown -c rolldown.config.mjs --watch",
     "typedoc": "typedoc --entryPointStrategy Expand --out ./docs/type/ ./src/",

--- a/rolldown.config.dts.mjs
+++ b/rolldown.config.dts.mjs
@@ -2,7 +2,7 @@ import { defineConfig } from 'rolldown';
 import { dts } from 'rolldown-plugin-dts';
 
 export default defineConfig({
-  input: './dist/dts/main.d.ts',
+  input: './dist/dts/index.d.ts',
   plugins: [dts()],
   output: {
     file: 'dist/index.d.ts',

--- a/rolldown.config.mjs
+++ b/rolldown.config.mjs
@@ -13,7 +13,7 @@ const banner = `/*!
 */`;
 
 export default defineConfig({
-  input: 'src/main.ts',
+  input: 'src/index.ts',
   output: [
     {
       file: 'dist/index.mjs',

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,2 @@
+export type { Comment } from "./@types/comment";
+export { default } from "./main";

--- a/tests/smoke/package-entrypoints.mjs
+++ b/tests/smoke/package-entrypoints.mjs
@@ -1,5 +1,12 @@
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -89,11 +96,26 @@ writeFileSync(
 writeFileSync(
   join(consumerDirectory, "types.ts"),
   [
-    'import Niwango from "@xpadev-net/niwango";',
+    'import Niwango, { type Comment } from "@xpadev-net/niwango";',
+    "",
+    "const comment: Comment = {",
+    '  message: "hello",',
+    "  vpos: 0,",
+    "  isYourPost: false,",
+    '  mail: "",',
+    "  fromButton: false,",
+    "  isPremium: false,",
+    "  color: 0xffffff,",
+    "  size: 2,",
+    "  no: 1,",
+    "  _vpos: 0,",
+    "  _owner: false,",
+    "};",
     "",
     "const Ctor: typeof Niwango = Niwango;",
     'const element = document.createElement("div");',
-    "const player = new Ctor(element, []);",
+    "const player = new Ctor(element, [comment]);",
+    "player.addComments(comment);",
     "const didDraw: boolean = player.draw(0);",
     "void didDraw;",
   ].join("\n"),
@@ -120,6 +142,30 @@ writeFileSync(
 
 run("node", ["esm.mjs"], { cwd: consumerDirectory });
 run("node", ["cjs.cjs"], { cwd: consumerDirectory });
+
+const installedDeclaration = join(
+  consumerDirectory,
+  "node_modules",
+  "@xpadev-net",
+  "niwango",
+  "dist",
+  "index.d.ts",
+);
+const declarationContent = readFileSync(installedDeclaration, "utf8");
+const sourceMapReferences = [
+  ...declarationContent.matchAll(/^\/\/# sourceMappingURL=(.+)$/gm),
+].map((match) => match[1]);
+for (const sourceMapReference of sourceMapReferences) {
+  const sourceMap = join(dirname(installedDeclaration), sourceMapReference);
+  if (!existsSync(sourceMap)) {
+    throw new Error(`Missing declaration source map: ${sourceMapReference}`);
+  }
+}
+console.log(
+  sourceMapReferences.length === 0
+    ? "Declaration source map references: none"
+    : `Declaration source map references: ${sourceMapReferences.length} found`,
+);
 
 const tscCommand = process.platform === "win32" ? "tsc.cmd" : "tsc";
 run(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
     "declaration": true,                   /* Generates corresponding '.d.ts' file. */
     "declarationDir": "./dist/dts",
-    "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    "declarationMap": false,               /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
     "outDir": "./dist/",                        /* Redirect output structure to the directory. */


### PR DESCRIPTION
## Summary
- add a package-root entry that re-exports the Niwango default and public Comment type
- bundle declarations from the public entry and disable declaration map emission so packed d.ts files do not reference missing maps
- extend packed-package smoke coverage for Niwango + Comment type imports and declaration source map references

## Validation
- pnpm test
- pnpm lint
- pnpm build
- npm pack --dry-run --ignore-scripts
- pnpm smoke:package (prints `Declaration source map references: none`)

## Review
- deep-review local pass: no actionable findings
- independent subagent review: no actionable findings

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes the public declaration package surface by introducing `src/index.ts` as the new package-root entry point that re-exports the `Niwango` default and the `Comment` type, and threads that entry through the rolldown and DTS bundling pipelines. `declarationMap` is also disabled in `tsconfig.json` to prevent packed `.d.ts` files from referencing `.d.ts.map` files that are not included in the published package.

- **`src/index.ts`**: New thin entry point that re-exports `Niwango` (default) and `Comment` (type) so consumers get both from a single import.
- **Build configs**: `rolldown.config.mjs` and `rolldown.config.dts.mjs` both updated from `main.ts`/`main.d.ts` to `index.ts`/`index.d.ts` as the bundle root.
- **Smoke tests**: Extended to exercise the named `Comment` type import and to assert no dangling source-map references survive in the packed `.d.ts`.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are additive or corrective with no removed exports and thorough smoke-test coverage of the exact scenarios being fixed.

The new entry point is a thin re-export shim; existing runtime behavior is unchanged. Disabling declarationMap eliminates the dangling source-map problem without side-effects since maps were never included in the published files list. The smoke test now exercises the complete pack→install→type-check loop for both the new named export and the absence of broken map references, giving strong confidence in the fix.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/index.ts | New package-root entry point that re-exports Niwango default and Comment type; paths are correct relative to the file location. |
| rolldown.config.mjs | Input changed from src/main.ts to src/index.ts; all output formats (ESM, CJS, UMD) remain unchanged and the type-only Comment re-export is safely erased at runtime. |
| rolldown.config.dts.mjs | Input changed from dist/dts/main.d.ts to dist/dts/index.d.ts to match the new entry point; no other changes. |
| tsconfig.json | declarationMap flipped from true to false to prevent broken source-map references in the bundled and packed dist/index.d.ts. |
| tests/smoke/package-entrypoints.mjs | Smoke test extended with Comment type usage, addComments call, and a source-map reference liveness check against the installed package tarball. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["src/index.ts\n(new entry point)"] -->|re-exports default| B["src/main.ts\nNiwango class"]
    A -->|re-exports type| C["src/@types/comment.d.ts\nComment interface"]

    A --> D["rolldown.config.mjs\nbuild:ts"]
    D --> E["dist/index.mjs (ESM)"]
    D --> F["dist/index.cjs (CJS)"]
    D --> G["dist/browser/niwango.js (UMD)"]

    A --> H["tsc --emitDeclarationOnly\n(declarationMap: false)"]
    H --> I["dist/dts/index.d.ts"]
    I --> J["rolldown.config.dts.mjs\nbuild:dts"]
    J --> K["dist/index.d.ts\n(no .d.ts.map refs)"]

    K --> L["npm pack tarball"]
    L --> M["smoke: install in temp dir"]
    M --> N["tsc type-check\nComment + Niwango imports"]
    M --> O["source-map ref check\nasserts: none found"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["src/index.ts\n(new entry point)"] -->|re-exports default| B["src/main.ts\nNiwango class"]
    A -->|re-exports type| C["src/@types/comment.d.ts\nComment interface"]

    A --> D["rolldown.config.mjs\nbuild:ts"]
    D --> E["dist/index.mjs (ESM)"]
    D --> F["dist/index.cjs (CJS)"]
    D --> G["dist/browser/niwango.js (UMD)"]

    A --> H["tsc --emitDeclarationOnly\n(declarationMap: false)"]
    H --> I["dist/dts/index.d.ts"]
    I --> J["rolldown.config.dts.mjs\nbuild:dts"]
    J --> K["dist/index.d.ts\n(no .d.ts.map refs)"]

    K --> L["npm pack tarball"]
    L --> M["smoke: install in temp dir"]
    M --> N["tsc type-check\nComment + Niwango imports"]
    M --> O["source-map ref check\nasserts: none found"]
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mas..."](https://github.com/xpadev-net/niwango.js/commit/9024ad151d8e4d99d5565a0e522edb7599a85348) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39461530)</sub>

<!-- /greptile_comment -->