### PR TITLE
Preserve mover state on snapshot restore

### DIFF
--- a/src/__tests__/snapshotMoverState.test.ts
+++ b/src/__tests__/snapshotMoverState.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import type { IrObjectMoverQueue } from "@/@types/IrObject";
+import { setCurrentTime } from "@/context";
+import { resetCanvas } from "@/contexts/canvas";
+import { drawObjects, resetObjects } from "@/contexts/objectManager";
+import {
+  resetSnapshot,
+  restoreSnapshot,
+  saveSnapshot,
+} from "@/contexts/snapshot";
+import { initConfig } from "@/definition/config";
+import { IrShape } from "@/objects/shape";
+import { IrText } from "@/objects/text";
+
+const createMockContext = () =>
+  ({
+    beginPath: vi.fn(),
+    clearRect: vi.fn(),
+    drawImage: vi.fn(),
+    ellipse: vi.fn(),
+    fill: vi.fn(),
+    fillRect: vi.fn(),
+    fillText: vi.fn(),
+    measureText: vi.fn((text: string) => ({
+      actualBoundingBoxAscent: 10,
+      actualBoundingBoxDescent: 2,
+      width: text.length * 10,
+    })),
+    restore: vi.fn(),
+    save: vi.fn(),
+    scale: vi.fn(),
+    strokeRect: vi.fn(),
+    strokeText: vi.fn(),
+  }) as unknown as CanvasRenderingContext2D;
+
+const getMoverQueue = (object: unknown) =>
+  (object as { moverQueue: IrObjectMoverQueue }).moverQueue;
+
+describe("snapshot mover state", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockImplementation(() =>
+      createMockContext(),
+    );
+    initConfig();
+    resetCanvas();
+    resetObjects();
+    resetSnapshot();
+    setCurrentTime(0);
+  });
+
+  test("restores moving text without jumping to the target position", () => {
+    const text = new IrText({
+      __id: "moving-text",
+      mover: "simple",
+      text: "move",
+      x: 0,
+      y: 0,
+    });
+    text.x = 100;
+    setCurrentTime(10);
+    const snapshottedX = text.__x;
+    saveSnapshot(10);
+
+    setCurrentTime(50);
+    restoreSnapshot(10);
+    setCurrentTime(10);
+
+    const restored = drawObjects[0];
+    expect(restored).toBeInstanceOf(IrText);
+    expect(restored?.__x).toBeCloseTo(snapshottedX);
+    expect(restored?.__x).not.toBeCloseTo(text.__x + 60);
+    expect(getMoverQueue(restored)).toEqual([
+      {
+        current: { x: 0, y: 0 },
+        diff: { x: 100, y: 0 },
+        duration: 25,
+        target: { x: 100, y: 0 },
+        vpos: 0,
+      },
+    ]);
+  });
+
+  test("restores moving shapes with their queued mover state", () => {
+    const shape = new IrShape({
+      __id: "moving-shape",
+      mover: "simple",
+      shape: "rect",
+      width: 20,
+      x: 0,
+      y: 0,
+    });
+    shape.x = 100;
+    setCurrentTime(10);
+    const snapshottedX = shape.__x;
+    saveSnapshot(10);
+
+    setCurrentTime(50);
+    restoreSnapshot(10);
+    setCurrentTime(10);
+
+    const restored = drawObjects[0];
+    expect(restored).toBeInstanceOf(IrShape);
+    expect(restored?.__x).toBeCloseTo(snapshottedX);
+    expect(getMoverQueue(restored)).toHaveLength(1);
+  });
+});

--- a/src/contexts/snapshot.ts
+++ b/src/contexts/snapshot.ts
@@ -37,7 +37,7 @@ const restoreSnapshot = (vpos: number) => {
   snapshots = snapshots.filter((s) => s.vpos <= snapshot.vpos);
   resetObjects();
   for (const obj of structuredClone(snapshot.drawObjects)) {
-    resultHook(obj);
+    restoreObjectLiteral(obj, true);
   }
   setQueue(structuredClone(snapshot.queue));
   setScripts(structuredClone(snapshot.scripts));
@@ -66,13 +66,25 @@ const getLatestSnapshotVpos = (vpos: number) => {
 };
 
 const resultHook = (input: unknown) => {
+  return restoreObjectLiteral(input);
+};
+
+const restoreObjectLiteral = (input: unknown, restoreState = false) => {
   if (typeof input === "object") {
     if (typeGuard.IrShapeLiteral(input)) {
       const shape = drawObjects.find((obj) => obj.__id === input.options.__id);
-      return shape ?? new IrShape(input.options);
+      const restoredShape = shape ?? new IrShape(input.options);
+      if (restoreState) {
+        restoredShape.__restoreSnapshotState(input);
+      }
+      return restoredShape;
     } else if (typeGuard.IrTextLiteral(input)) {
       const text = drawObjects.find((obj) => obj.__id === input.options.__id);
-      return text ?? new IrText(input.options);
+      const restoredText = text ?? new IrText(input.options);
+      if (restoreState) {
+        restoredText.__restoreSnapshotState(input);
+      }
+      return restoredText;
     }
   }
   return input;

--- a/src/objects/object.ts
+++ b/src/objects/object.ts
@@ -18,6 +18,8 @@ import {
 } from "@/utils/object";
 import { uuid } from "@/utils/uuid";
 
+type SnapshotRecord = Record<string, unknown>;
+
 const defaultOptions: IObjectOptions = {
   x: 0,
   y: 0,
@@ -313,6 +315,29 @@ abstract class IrObject {
     console.debug("please override this method");
   }
 
+  public __restoreSnapshotState(snapshot: unknown) {
+    if (!IrObject.__isSnapshotRecord(snapshot)) return;
+
+    const moverQueue = IrObject.__normalizeMoverQueue(snapshot.moverQueue);
+    if (moverQueue) {
+      this.moverQueue = moverQueue;
+    }
+    if (typeof snapshot.__modified === "boolean") {
+      this.__modified = snapshot.__modified;
+    }
+    if (
+      typeof snapshot.__creationVpos === "number" &&
+      Number.isFinite(snapshot.__creationVpos)
+    ) {
+      Object.defineProperty(this, "__creationVpos", {
+        configurable: true,
+        enumerable: true,
+        value: snapshot.__creationVpos,
+        writable: true,
+      });
+    }
+  }
+
   protected get __isModified() {
     return (
       this.__modified ||
@@ -380,6 +405,57 @@ abstract class IrObject {
       return queue.target[axis] - pos;
     }
     return queue.target[axis];
+  }
+
+  private static __isSnapshotRecord(
+    snapshot: unknown,
+  ): snapshot is SnapshotRecord {
+    return (
+      typeof snapshot === "object" &&
+      snapshot !== null &&
+      !Array.isArray(snapshot)
+    );
+  }
+
+  private static __normalizeMoverQueue(
+    queue: unknown,
+  ): IrObjectMoverQueue | null {
+    if (!Array.isArray(queue)) return null;
+
+    const moverQueue: IrObjectMoverQueue = [];
+    for (const item of queue) {
+      if (!IrObject.__isSnapshotRecord(item)) continue;
+      const { current, target, diff, vpos, duration } = item;
+      if (
+        !IrObject.__isPos(current) ||
+        !IrObject.__isPos(target) ||
+        !IrObject.__isPos(diff) ||
+        typeof vpos !== "number" ||
+        !Number.isFinite(vpos) ||
+        typeof duration !== "number" ||
+        !Number.isFinite(duration)
+      ) {
+        continue;
+      }
+      moverQueue.push({
+        current: { ...current },
+        target: { ...target },
+        diff: { ...diff },
+        vpos,
+        duration,
+      });
+    }
+    return moverQueue;
+  }
+
+  private static __isPos(pos: unknown): pos is IrObjectPos {
+    return (
+      IrObject.__isSnapshotRecord(pos) &&
+      typeof pos.x === "number" &&
+      Number.isFinite(pos.x) &&
+      typeof pos.y === "number" &&
+      Number.isFinite(pos.y)
+    );
   }
 }
 

--- a/src/objects/object.ts
+++ b/src/objects/object.ts
@@ -319,7 +319,7 @@ abstract class IrObject {
     if (!IrObject.__isSnapshotRecord(snapshot)) return;
 
     const moverQueue = IrObject.__normalizeMoverQueue(snapshot.moverQueue);
-    if (moverQueue) {
+    if (moverQueue !== null) {
       this.moverQueue = moverQueue;
     }
     if (typeof snapshot.__modified === "boolean") {


### PR DESCRIPTION
## Summary
- Restore snapshot-only IrObject mover state when replaying saved IrText/IrShape literals
- Keep normal resultHook literal construction unchanged for non-snapshot results
- Add regression coverage for text and shape movement restored mid-move

## Validation
- pnpm test
- pnpm lint
- pnpm build

## Review
- deep-review self pass: no actionable findings
- independent subagent review: no actionable findings

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes snapshot restore so that objects mid-animation resume from their saved interpolation state rather than jumping to the final target position. It does this by adding `__restoreSnapshotState` to `IrObject` and threading a `restoreState` flag through the new `restoreObjectLiteral` helper in `snapshot.ts`.

- **`src/objects/object.ts`**: Adds `__restoreSnapshotState(snapshot)` to reapply `moverQueue`, `__modified`, and `__creationVpos` from the cloned snapshot literal. Private statics `__normalizeMoverQueue` and `__isPos` validate queue data defensively before writing it.
- **`src/contexts/snapshot.ts`**: Refactors `resultHook` to delegate to a new `restoreObjectLiteral(input, restoreState?)` function; snapshot replay calls it with `restoreState = true`, keeping the non-snapshot hook path unchanged.
- **`src/__tests__/snapshotMoverState.test.ts`**: Adds regression tests for mid-move text and shape restore, verifying position continuity and queue integrity after `restoreSnapshot`.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrowly scoped to snapshot restore and does not touch the live draw or mover-update paths.

The mover-queue normalization validates every field before writing, the null-sentinel return is guarded with !== null, Object.defineProperty correctly overrides the readonly __creationVpos, and regression tests confirm position continuity for both IrText and IrShape mid-move restores.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/objects/object.ts | Adds __restoreSnapshotState and three private static helpers; validation logic for moverQueue items is thorough, readonly __creationVpos is overridden via Object.defineProperty correctly, and the null-sentinel return from __normalizeMoverQueue is handled with the explicit !== null guard. |
| src/contexts/snapshot.ts | Refactors resultHook to delegate to restoreObjectLiteral; snapshot restore now passes restoreState=true to reapply mover state, while the live resultHook path is unchanged. Return value of restoreObjectLiteral is intentionally unused in the restore loop since IrObject constructors self-register. |
| src/__tests__/snapshotMoverState.test.ts | New regression tests exercise text and shape restore mid-move; the IrText test verifies exact queue contents and position continuity, while the IrShape test verifies queue length. Coverage is meaningful and the setup/teardown is consistent with other test files. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant snapshot.ts
    participant IrShape/IrText
    participant IrObject

    Caller->>snapshot.ts: restoreSnapshot(vpos)
    snapshot.ts->>snapshot.ts: resetObjects()
    loop for each cloned literal in snapshot.drawObjects
        snapshot.ts->>snapshot.ts: "restoreObjectLiteral(obj, restoreState=true)"
        snapshot.ts->>IrShape/IrText: new IrShape/IrText(input.options)
        IrShape/IrText->>IrObject: constructor register(this)
        snapshot.ts->>IrObject: __restoreSnapshotState(input)
        IrObject->>IrObject: __normalizeMoverQueue(snapshot.moverQueue)
        IrObject->>IrObject: "this.moverQueue = normalizedQueue"
        IrObject->>IrObject: "this.__modified = snapshot.__modified"
        IrObject->>IrObject: Object.defineProperty(__creationVpos)
    end
    snapshot.ts-->>Caller: restored vpos
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant snapshot.ts
    participant IrShape/IrText
    participant IrObject

    Caller->>snapshot.ts: restoreSnapshot(vpos)
    snapshot.ts->>snapshot.ts: resetObjects()
    loop for each cloned literal in snapshot.drawObjects
        snapshot.ts->>snapshot.ts: "restoreObjectLiteral(obj, restoreState=true)"
        snapshot.ts->>IrShape/IrText: new IrShape/IrText(input.options)
        IrShape/IrText->>IrObject: constructor register(this)
        snapshot.ts->>IrObject: __restoreSnapshotState(input)
        IrObject->>IrObject: __normalizeMoverQueue(snapshot.moverQueue)
        IrObject->>IrObject: "this.moverQueue = normalizedQueue"
        IrObject->>IrObject: "this.__modified = snapshot.__modified"
        IrObject->>IrObject: Object.defineProperty(__creationVpos)
    end
    snapshot.ts-->>Caller: restored vpos
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mas..."](https://github.com/xpadev-net/niwango.js/commit/8c2a859739f9095f50aaf731dbf9b84ce76cf9f8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39464014)</sub>

<!-- /greptile_comment -->