### PR TITLE
Validate Niwango constructor target

### DIFF
--- a/src/__tests__/niwango.test.ts
+++ b/src/__tests__/niwango.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 
 import type { Comment } from "@/@types/comment";
 import { comments } from "@/context";
@@ -6,6 +6,77 @@ import Niwango from "@/main";
 import { run } from "@/testUtils";
 
 type CommentBoundary = (commentInputs: unknown[]) => void;
+
+const targetElementTypeError =
+  "Niwango constructor targetElement must be an HTMLDivElement or HTMLCanvasElement.";
+
+const createMockCanvasContext = () =>
+  ({
+    clearRect: vi.fn(),
+    drawImage: vi.fn(),
+    restore: vi.fn(),
+    rotate: vi.fn(),
+    save: vi.fn(),
+    scale: vi.fn(),
+    translate: vi.fn(),
+  }) as unknown as CanvasRenderingContext2D;
+
+const createIframeWindow = () => {
+  const iframe = document.createElement("iframe");
+  document.body.append(iframe);
+  const iframeWindow = iframe.contentWindow as
+    | (Window & typeof globalThis)
+    | null;
+  if (!iframeWindow) {
+    iframe.remove();
+    throw new Error("missing iframe window");
+  }
+  return { iframe, iframeWindow };
+};
+
+const createElementWithSpoofedPrototype = (
+  localName: string,
+  prototype: object,
+) => {
+  const targetElement = document.createElement(localName);
+  Object.setPrototypeOf(targetElement, prototype);
+  return targetElement;
+};
+
+const createElementWithSpoofedLocalNameAndPrototype = (
+  localName: string,
+  spoofedLocalName: string,
+  prototype: object,
+) => {
+  const targetElement = createElementWithSpoofedPrototype(localName, prototype);
+  Object.defineProperty(targetElement, "localName", {
+    value: spoofedLocalName,
+  });
+  return targetElement;
+};
+
+const createElementWithSpoofedOwnerDocumentLocalNameAndPrototype = (
+  localName: string,
+  spoofedLocalName: string,
+  prototype: object,
+) => {
+  const targetElement = createElementWithSpoofedLocalNameAndPrototype(
+    localName,
+    spoofedLocalName,
+    prototype,
+  );
+  Object.defineProperty(targetElement, "ownerDocument", {
+    value: {
+      defaultView: {
+        Element: Object,
+        HTMLDivElement: {
+          [Symbol.hasInstance]: () => true,
+        },
+      },
+    },
+  });
+  return targetElement;
+};
 
 const createComment = (overrides: Partial<Comment> = {}): Comment => ({
   message: "hello",
@@ -45,6 +116,10 @@ const expectBoundaryToSkipOnlyInvalid = (
   expect(comments).toEqual([validComment]);
   expect(comments[0]).toBe(validComment);
 };
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 test("rand", () => {
   const rand1 = run(`rand("hoge")`);
@@ -105,6 +180,116 @@ test("constructor treats non-array comments input as empty", () => {
       new Niwango(document.createElement("div"), null as unknown as Comment[]),
   ).not.toThrow();
   expect(comments).toEqual([]);
+});
+
+test("constructor accepts div target elements", () => {
+  expect(
+    () => new Niwango(document.createElement("div"), [] satisfies Comment[]),
+  ).not.toThrow();
+});
+
+test("constructor accepts canvas target elements", () => {
+  vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(
+    createMockCanvasContext(),
+  );
+
+  expect(
+    () => new Niwango(document.createElement("canvas"), [] satisfies Comment[]),
+  ).not.toThrow();
+});
+
+test("constructor accepts div target elements from another DOM realm", () => {
+  const { iframe, iframeWindow } = createIframeWindow();
+  try {
+    expect(
+      () =>
+        new Niwango(
+          iframeWindow.document.createElement("div"),
+          [] satisfies Comment[],
+        ),
+    ).not.toThrow();
+  } finally {
+    iframe.remove();
+  }
+});
+
+test("constructor accepts canvas target elements from another DOM realm", () => {
+  const { iframe, iframeWindow } = createIframeWindow();
+  vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(
+    createMockCanvasContext(),
+  );
+  vi.spyOn(
+    iframeWindow.HTMLCanvasElement.prototype,
+    "getContext",
+  ).mockReturnValue(createMockCanvasContext());
+
+  try {
+    expect(
+      () =>
+        new Niwango(
+          iframeWindow.document.createElement("canvas"),
+          [] satisfies Comment[],
+        ),
+    ).not.toThrow();
+  } finally {
+    iframe.remove();
+  }
+});
+
+test.each([
+  ["span", document.createElement("span")],
+  ["null", null],
+  ["undefined", undefined],
+  ["plain object", {}],
+  ["object with canvas-like nodeName", { nodeName: "CANVAS" }],
+  ["object with div prototype", Object.create(HTMLDivElement.prototype)],
+  ["object with canvas prototype", Object.create(HTMLCanvasElement.prototype)],
+  [
+    "span element with div prototype",
+    createElementWithSpoofedPrototype("span", HTMLDivElement.prototype),
+  ],
+  [
+    "span element with spoofed localName and div prototype",
+    createElementWithSpoofedLocalNameAndPrototype(
+      "span",
+      "div",
+      HTMLDivElement.prototype,
+    ),
+  ],
+  [
+    "span element with spoofed ownerDocument, localName, and div prototype",
+    createElementWithSpoofedOwnerDocumentLocalNameAndPrototype(
+      "span",
+      "div",
+      HTMLDivElement.prototype,
+    ),
+  ],
+  [
+    "object with spoofed ownerDocument",
+    {
+      ownerDocument: {
+        defaultView: {
+          Element: Object,
+          HTMLDivElement: Object,
+        },
+      },
+    },
+  ],
+])("constructor rejects unsupported target: %s", (_name, targetElement) => {
+  expect(
+    () =>
+      new Niwango(
+        targetElement as HTMLCanvasElement | HTMLDivElement,
+        [] satisfies Comment[],
+      ),
+  ).toThrow(TypeError);
+  expect(
+    () =>
+      new Niwango(
+        targetElement as HTMLCanvasElement | HTMLDivElement,
+        [] satisfies Comment[],
+      ),
+  ).toThrow(targetElementTypeError);
 });
 
 describe.each([

--- a/src/main.ts
+++ b/src/main.ts
@@ -76,6 +76,60 @@ const addCommentScript = (comment: Comment) => {
   }
 };
 
+type TargetElementDefinition = {
+  localName: "canvas" | "div";
+};
+
+const HTML_NAMESPACE = "http://www.w3.org/1999/xhtml";
+
+const getElementProperty = (
+  targetElement: unknown,
+  propertyName: "localName" | "namespaceURI",
+) => {
+  const propertyGetter = Object.getOwnPropertyDescriptor(
+    globalThis.Element?.prototype ?? {},
+    propertyName,
+  )?.get;
+  if (typeof propertyGetter !== "function") {
+    return undefined;
+  }
+  try {
+    return propertyGetter.call(targetElement);
+  } catch (_e) {
+    return undefined;
+  }
+};
+
+const isTargetElement = <T extends Element>(
+  targetElement: unknown,
+  { localName }: TargetElementDefinition,
+): targetElement is T => {
+  return (
+    getElementProperty(targetElement, "namespaceURI") === HTML_NAMESPACE &&
+    getElementProperty(targetElement, "localName") === localName
+  );
+};
+
+const createRender = (targetElement: unknown): IRender => {
+  if (
+    isTargetElement<HTMLDivElement>(targetElement, {
+      localName: "div",
+    })
+  ) {
+    return new DomRender(targetElement);
+  }
+  if (
+    isTargetElement<HTMLCanvasElement>(targetElement, {
+      localName: "canvas",
+    })
+  ) {
+    return new CanvasRender(targetElement);
+  }
+  throw new TypeError(
+    "Niwango constructor targetElement must be an HTMLDivElement or HTMLCanvasElement.",
+  );
+};
+
 class Niwango {
   private readonly render: IRender;
   static default = Niwango;
@@ -86,11 +140,7 @@ class Niwango {
   ) {
     setup();
     initConfig();
-    if (targetElement.nodeName === "DIV") {
-      this.render = new DomRender(targetElement as HTMLDivElement);
-    } else {
-      this.render = new CanvasRender(targetElement as HTMLCanvasElement);
-    }
+    this.render = createRender(targetElement);
     this.lastVpos = -1;
 
     const normalizedComments = normalizeComments(comments);


### PR DESCRIPTION
## Summary
- add runtime narrowing for the public Niwango constructor target element
- accept actual HTML div/canvas targets, including cross-realm elements
- reject unsupported/nullish/spoofed targets with a clear TypeError before renderer failures

## Validation
- pnpm test
- pnpm lint
- pnpm build

## Review
- deep-review self pass with independent subagent review loops; final independent pass reported no actionable findings

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR hardens the `Niwango` constructor's target element validation by replacing the fragile `nodeName === "DIV"` string comparison with a tamper-proof check that invokes native `Element.prototype` getters directly to read `namespaceURI` and `localName` from the element's internal slots. A `TypeError` is thrown for any input that is not a real HTML div or canvas — including null, plain objects, prototype-spoofed elements, and spoofed property descriptors.

- **`src/main.ts`**: Introduces `getElementProperty`, `isTargetElement`, and `createRender`. The new approach calls the getter obtained via `Object.getOwnPropertyDescriptor(globalThis.Element?.prototype, ...)` with `.call(targetElement)`, which reads internal DOM slots and is immune to own-property or prototype spoofing. Cross-realm elements (from iframes) are accepted because native getters operate across realms in browsers.
- **`src/__tests__/niwango.test.ts`**: Adds a comprehensive suite covering same-realm div/canvas acceptance, cross-realm (iframe) div/canvas acceptance, and rejection of spans, null, undefined, plain objects, elements with spoofed prototypes, spoofed `localName` own properties, and spoofed `ownerDocument.defaultView` setups.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the validation logic is correct, the spoofing attack surface is closed, and cross-realm elements are handled properly.

The native-getter approach correctly reads internal DOM slots, making it immune to prototype swaps and own-property overrides. The cross-realm path works because native getters in browsers (and JSDOM's JavaScript-level slot access) are not bounded by realm. The test suite directly exercises all the relevant attack vectors and acceptance scenarios. DomRender and CanvasRender downstream consumers are unchanged and remain compatible.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/main.ts | Replaces nodeName-string check with native-getter-based validation; logic is correct, immune to prototype and own-property spoofing, and correctly handles cross-realm elements. |
| src/__tests__/niwango.test.ts | Comprehensive new test suite covering valid, cross-realm, and all spoofing rejection scenarios; afterEach cleanup with vi.restoreAllMocks is correctly placed. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Niwango constructor\ntargetElement: unknown] --> B[createRender]
    B --> C[getElementProperty\nnative namespaceURI getter\nvia globalThis.Element.prototype]
    C --> D{namespaceURI ===\nhttp://www.w3.org/1999/xhtml?}
    D -- No / undefined --> E[TypeError\nunsupported target]
    D -- Yes --> F[getElementProperty\nnative localName getter\nvia globalThis.Element.prototype]
    F --> G{localName === 'div'?}
    G -- Yes --> H[new DomRender\ntargetElement as HTMLDivElement]
    G -- No --> I{localName === 'canvas'?}
    I -- Yes --> J[new CanvasRender\ntargetElement as HTMLCanvasElement]
    I -- No --> E

    style E fill:#f55,color:#fff
    style H fill:#5a5,color:#fff
    style J fill:#5a5,color:#fff
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Niwango constructor\ntargetElement: unknown] --> B[createRender]
    B --> C[getElementProperty\nnative namespaceURI getter\nvia globalThis.Element.prototype]
    C --> D{namespaceURI ===\nhttp://www.w3.org/1999/xhtml?}
    D -- No / undefined --> E[TypeError\nunsupported target]
    D -- Yes --> F[getElementProperty\nnative localName getter\nvia globalThis.Element.prototype]
    F --> G{localName === 'div'?}
    G -- Yes --> H[new DomRender\ntargetElement as HTMLDivElement]
    G -- No --> I{localName === 'canvas'?}
    I -- Yes --> J[new CanvasRender\ntargetElement as HTMLCanvasElement]
    I -- No --> E

    style E fill:#f55,color:#fff
    style H fill:#5a5,color:#fff
    style J fill:#5a5,color:#fff
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mas..."](https://github.com/xpadev-net/niwango.js/commit/fe7d1df2ea0ad5ac201c24bc137d34d90de45001) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39464565)</sub>

<!-- /greptile_comment -->