### PR TITLE
Restore snapshot current time state

### DIFF
--- a/src/@types/types.d.ts
+++ b/src/@types/types.d.ts
@@ -57,6 +57,7 @@ export type IHandler = {
 };
 export type ISnapshot = {
   vpos: number;
+  currentTime: number;
   queue: IQueue[];
   scripts: Script[];
   handlers: IHandler[];

--- a/src/__tests__/niwango.test.ts
+++ b/src/__tests__/niwango.test.ts
@@ -1,7 +1,9 @@
+import type { A_ANY } from "@xpadev-net/niwango-core";
+import Core from "@xpadev-net/niwango-core";
 import { afterEach, describe, expect, test, vi } from "vitest";
-
 import type { Comment } from "@/@types/comment";
-import { comments } from "@/context";
+import { comments, currentTime } from "@/context";
+import { addHandler } from "@/contexts/commentHandler";
 import Niwango from "@/main";
 import { run } from "@/testUtils";
 
@@ -172,6 +174,34 @@ test("draw limits forward seeks from the current vpos", () => {
   expect(niwango.draw(10)).toBe(true);
   expect(niwango.draw(100_011)).toBe(false);
   expect(niwango.draw(100_012)).toBe(true);
+});
+
+test("draw restores processed comment time when rewinding to a snapshot", () => {
+  const handlerScript: A_ANY = { type: "Raw", value: "handler" };
+  const handlerScopes = [{}, {}, {}];
+  const execute = vi.spyOn(Core, "execute").mockReturnValue(undefined);
+  const niwango = new Niwango(document.createElement("div"), [
+    createComment({ no: 1, message: "before snapshot", _vpos: 900 }),
+    createComment({ no: 2, message: "after snapshot", _vpos: 1050 }),
+  ]);
+  addHandler(handlerScript, handlerScopes, [], 0);
+
+  expect(niwango.draw(1500)).toBe(true);
+  expect(execute).toHaveBeenCalledTimes(2);
+  expect(currentTime).toBe(1050);
+
+  expect(niwango.draw(1050)).toBe(true);
+
+  expect(execute).toHaveBeenCalledTimes(3);
+  expect(execute).toHaveBeenLastCalledWith(handlerScript, handlerScopes, [
+    handlerScript,
+  ]);
+  const replayedScopes = execute.mock.calls[2]?.[1];
+  expect(replayedScopes).not.toBe(handlerScopes);
+  expect(replayedScopes?.[0]).toMatchObject({
+    chat: expect.objectContaining({ message: "after snapshot", _vpos: 1050 }),
+  });
+  expect(currentTime).toBe(1050);
 });
 
 test("constructor treats non-array comments input as empty", () => {

--- a/src/__tests__/snapshotMoverState.test.ts
+++ b/src/__tests__/snapshotMoverState.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 import type { IrObjectMoverQueue } from "@/@types/IrObject";
-import { setCurrentTime } from "@/context";
+import { currentTime, setCurrentTime } from "@/context";
 import { resetCanvas } from "@/contexts/canvas";
 import { drawObjects, resetObjects } from "@/contexts/objectManager";
 import {
@@ -104,5 +104,15 @@ describe("snapshot mover state", () => {
     expect(restored).toBeInstanceOf(IrShape);
     expect(restored?.__x).toBeCloseTo(snapshottedX);
     expect(getMoverQueue(restored)).toHaveLength(1);
+  });
+
+  test("restores the current time captured with the snapshot", () => {
+    setCurrentTime(900);
+    saveSnapshot(1000);
+
+    setCurrentTime(1050);
+    restoreSnapshot(1000);
+
+    expect(currentTime).toBe(900);
   });
 });

--- a/src/contexts/snapshot.ts
+++ b/src/contexts/snapshot.ts
@@ -1,6 +1,7 @@
 import Core from "@xpadev-net/niwango-core";
 
 import type { ISnapshot } from "@/@types/types";
+import { currentTime, setCurrentTime } from "@/context";
 import { handlers, setHandlers } from "@/contexts/commentHandler";
 import { drawObjects, resetObjects } from "@/contexts/objectManager";
 import { queue, setQueue } from "@/contexts/queue";
@@ -21,6 +22,7 @@ let snapshots: ISnapshot[] = [];
 const saveSnapshot = (vpos: number) => {
   snapshots.push({
     vpos,
+    currentTime,
     queue: structuredClone(queue),
     scripts: structuredClone(scripts),
     handlers: structuredClone(handlers),
@@ -44,6 +46,7 @@ const restoreSnapshot = (vpos: number) => {
   setHandlers(structuredClone(snapshot.handlers));
   setGlobalScope(structuredClone(snapshot.globalScope));
   setEnvironmentScope(structuredClone(snapshot.environmentScope));
+  setCurrentTime(snapshot.currentTime);
   return snapshot.vpos;
 };
 


### PR DESCRIPTION
## Summary
- save currentTime in snapshots and restore it with queues, scripts, handlers, scopes, and draw objects
- add rewind regression covering comment handler replay after a large rewind
- add direct snapshot assertion that restored snapshots reset currentTime

## Validation
- pnpm test
- pnpm lint
- pnpm build
- pre-commit hook: biome-check, check-types, test

## Review
- deep-review self pass: no actionable findings after tightening restored-scope assertions
- independent subagent review: no actionable findings

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a state-restoration bug where `currentTime` was not included in snapshots, causing comment handlers to skip comments on rewind. Since `getComments()` in `commentHandler.ts` uses `currentTime` as a lower-bound filter (`comment._vpos > currentTime`), restoring a snapshot while leaving `currentTime` at the post-playback value caused rewound comments at that exact vpos to silently disappear on replay.

- Adds `currentTime: number` to the `ISnapshot` type and saves/restores it alongside queues, scripts, handlers, scopes, and draw objects in `snapshot.ts`.
- Adds two targeted tests: a direct snapshot unit test asserting `currentTime` is reset on restore, and an integration regression test verifying that a comment handler is correctly re-invoked with the right comment after a large backward seek.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is minimal and directly closes a replay gap without touching the draw loop, snapshot scheduling, or any public API.

The core change is a one-liner save and one-liner restore of a single integer. `currentTime` is exclusively written via `setCurrentTime` and is not accessed during `__restoreSnapshotState`, so the placement at the end of `restoreSnapshot` is correct and order-independent. The new integration test in `niwango.test.ts` fully exercises the before/after states, and the direct assertion in `snapshotMoverState.test.ts` pins the contract. Existing mover tests continue to pass because the snapshot captures `currentTime` at the same value the tests set it to before saving, making the previously explicit post-restore `setCurrentTime` calls harmless no-ops.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/contexts/snapshot.ts | Correctly saves and restores `currentTime` alongside all other snapshot state; `setCurrentTime` is called at the end of `restoreSnapshot` after object and scope restoration, which is safe since `__restoreSnapshotState` does not read `currentTime`. |
| src/@types/types.d.ts | Adds the required `currentTime: number` field to the internal `ISnapshot` type; `ISnapshot` is not exported from the package, so this is not a breaking API change. |
| src/__tests__/snapshotMoverState.test.ts | Adds a direct unit test asserting that `currentTime` is restored to its snapshotted value; existing tests retain explicit `setCurrentTime` calls after `restoreSnapshot` that are now redundant but harmless. |
| src/__tests__/niwango.test.ts | Adds an integration regression test using internal module access (`addHandler`, `currentTime`) to verify that a comment handler is re-invoked after a large backward seek with the correct comment in a fresh (non-aliased) scope. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Main as main.ts (execute loop)
    participant Snap as snapshot.ts
    participant Ctx as context.ts (currentTime)
    participant CH as commentHandler.ts

    Note over Main: draw(1500) — forward playback
    Main->>Ctx: "setCurrentTime(queue.time) [vpos=900]"
    Main->>CH: "triggerHandlers(comment@900)"
    Main->>Ctx: "setCurrentTime(queue.time) [vpos=1000]"
    Main->>Snap: saveSnapshot(1000)
    Snap->>Ctx: "read currentTime (=900)"
    Note over Snap: snapshot stores currentTime=900
    Main->>Ctx: "setCurrentTime(queue.time) [vpos=1050]"
    Main->>CH: "triggerHandlers(comment@1050)"
    Note over Ctx: currentTime = 1050

    Note over Main: draw(1050) — backward seek
    Main->>Snap: restoreSnapshot(1000)
    Snap->>Ctx: "setCurrentTime(snapshot.currentTime=900)"
    Note over Ctx: currentTime = 900
    Main->>CH: getComments(1050)
    Note over CH: filter: _vpos<=1050 && _vpos>900 → comment@1050 included
    Main->>Ctx: setCurrentTime(1050)
    Main->>CH: "triggerHandlers(comment@1050)"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Main as main.ts (execute loop)
    participant Snap as snapshot.ts
    participant Ctx as context.ts (currentTime)
    participant CH as commentHandler.ts

    Note over Main: draw(1500) — forward playback
    Main->>Ctx: "setCurrentTime(queue.time) [vpos=900]"
    Main->>CH: "triggerHandlers(comment@900)"
    Main->>Ctx: "setCurrentTime(queue.time) [vpos=1000]"
    Main->>Snap: saveSnapshot(1000)
    Snap->>Ctx: "read currentTime (=900)"
    Note over Snap: snapshot stores currentTime=900
    Main->>Ctx: "setCurrentTime(queue.time) [vpos=1050]"
    Main->>CH: "triggerHandlers(comment@1050)"
    Note over Ctx: currentTime = 1050

    Note over Main: draw(1050) — backward seek
    Main->>Snap: restoreSnapshot(1000)
    Snap->>Ctx: "setCurrentTime(snapshot.currentTime=900)"
    Note over Ctx: currentTime = 900
    Main->>CH: getComments(1050)
    Note over CH: filter: _vpos<=1050 && _vpos>900 → comment@1050 included
    Main->>Ctx: setCurrentTime(1050)
    Main->>CH: "triggerHandlers(comment@1050)"
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Restore snapshot current time state"](https://github.com/xpadev-net/niwango.js/commit/f5a0fb239928e2cc1982f8b8533d97c6a78325b9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39467351)</sub>

<!-- /greptile_comment -->