### PR TITLE
Unify addComments vpos policy

### DIFF
--- a/src/__tests__/niwango.test.ts
+++ b/src/__tests__/niwango.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 import type { Comment } from "@/@types/comment";
 import { comments, currentTime } from "@/context";
 import { addHandler } from "@/contexts/commentHandler";
+import { environmentScope, globalScope } from "@/contexts/scope";
 import Niwango from "@/main";
 import { run } from "@/testUtils";
 
@@ -202,6 +203,78 @@ test("draw restores processed comment time when rewinding to a snapshot", () => 
     chat: expect.objectContaining({ message: "after snapshot", _vpos: 1050 }),
   });
   expect(currentTime).toBe(1050);
+});
+
+test.each([
+  ["past", 5],
+  ["same", 10],
+])("addComments ignores %s-vpos additions that playback has already reached", (_name, commentVpos) => {
+  const handlerScript: A_ANY = { type: "Raw", value: "handler" };
+  const ownerScript: A_ANY = { type: "Raw", value: "owner" };
+  const handlerScopes = [{}, {}, Core.prototypeScope];
+  const execute = vi.spyOn(Core, "execute").mockReturnValue(undefined);
+  vi.spyOn(Core, "parseScript").mockReturnValue(ownerScript);
+  const niwango = createNiwango();
+
+  addHandler(handlerScript, handlerScopes, [], 0);
+  expect(niwango.draw(10)).toBe(true);
+
+  niwango.addComments(
+    createComment({
+      no: 2,
+      message: "already reached",
+      _vpos: commentVpos,
+      vpos: commentVpos,
+    }),
+    createComment({
+      no: 3,
+      message: "/alreadyReached()",
+      _owner: true,
+      _vpos: commentVpos,
+      vpos: commentVpos,
+    }),
+  );
+
+  expect(niwango.draw(11)).toBe(true);
+  expect(execute).not.toHaveBeenCalled();
+});
+
+test("addComments dispatches future-vpos additions when playback reaches them", () => {
+  const handlerScript: A_ANY = { type: "Raw", value: "handler" };
+  const ownerScript: A_ANY = { type: "Raw", value: "owner" };
+  const handlerScopes = [{}, {}, Core.prototypeScope];
+  const execute = vi.spyOn(Core, "execute").mockReturnValue(undefined);
+  vi.spyOn(Core, "parseScript").mockReturnValue(ownerScript);
+  const niwango = createNiwango();
+
+  addHandler(handlerScript, handlerScopes, [], 0);
+  expect(niwango.draw(10)).toBe(true);
+
+  niwango.addComments(
+    createComment({ no: 2, message: "future", _vpos: 11, vpos: 11 }),
+    createComment({
+      no: 3,
+      message: "/future()",
+      _owner: true,
+      _vpos: 11,
+      vpos: 11,
+    }),
+  );
+
+  expect(niwango.draw(11)).toBe(true);
+  expect(execute).toHaveBeenCalledTimes(2);
+  expect(execute).toHaveBeenNthCalledWith(
+    1,
+    expect.objectContaining(ownerScript),
+    [globalScope, environmentScope, Core.prototypeScope],
+    [expect.objectContaining(ownerScript)],
+  );
+  expect(execute).toHaveBeenNthCalledWith(2, handlerScript, handlerScopes, [
+    handlerScript,
+  ]);
+  expect(handlerScopes[0]).toMatchObject({
+    chat: expect.objectContaining({ message: "future", _vpos: 11 }),
+  });
 });
 
 test("constructor treats non-array comments input as empty", () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -253,8 +253,11 @@ class Niwango {
 
   public addComments(...newComments: Comment[]) {
     const normalizedComments = normalizeComments(newComments);
-    normalizedComments.forEach(addCommentScript);
-    setComments([...comments, ...normalizedComments]);
+    const futureComments = normalizedComments.filter(
+      (comment) => comment._vpos > this.lastVpos,
+    );
+    futureComments.forEach(addCommentScript);
+    setComments([...comments, ...futureComments]);
   }
 }
 


### PR DESCRIPTION
## Summary
- Ignore addComments entries whose _vpos has already been reached, including same-vpos additions
- Keep constructor comments as pre-playback input and dispatch future addComments entries normally
- Add regressions for past, same-vpos, and future additions covering normal comments and owner-script comments

## Validation
- pnpm vitest run src/__tests__/niwango.test.ts
- pnpm test
- pnpm lint
- pnpm build
- pre-commit hook: biome-check, check-types, test

## Review
- Independent subagent review: no actionable findings

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR tightens the `addComments` vpos policy so that dynamically added comments whose `_vpos` has already been reached (including same-vpos) are silently dropped, while constructor-time comments remain unfiltered as pre-playback input. Three regression tests are added covering past, same-vpos, and future additions for both normal and owner-script comments.

- **`src/main.ts`**: `addComments` now filters out any comment where `comment._vpos <= this.lastVpos` before calling `addCommentScript` and `setComments`, preventing already-passed vpos owner scripts from being queued and handlers from being triggered retroactively.
- **`src/__tests__/niwango.test.ts`**: New `test.each` for past/same-vpos ignoring and a standalone test for future-vpos dispatch; also imports `environmentScope`/`globalScope` to assert the exact scopes passed to `Core.execute`.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the one-line filter change is well-scoped, tests cover all three boundary cases, and the existing shared boundary tests continue to pass because they start from a fresh instance.

The change is minimal: a single `.filter` call added to `addComments` with a clear, intentional predicate. Constructor semantics are untouched, rewind behaviour is unaffected, and the downstream plugin simply forwards calls through so it benefits from the fix automatically. The new tests directly verify each variant of the policy.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/main.ts | Adds a `_vpos > lastVpos` filter in `addComments` to drop past/same-vpos comments; logic is correct and consistent with constructor semantics. |
| src/__tests__/niwango.test.ts | Adds three regression tests (past, same-vpos, future) for the new `addComments` filtering; existing shared boundary tests remain valid because they use a fresh instance with `lastVpos = -1`. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant Niwango
    participant Scripts as addCommentScript / setComments

    Note over Niwango: constructor — lastVpos = -1
    Caller->>Niwango: new Niwango(el, comments)
    Niwango->>Scripts: forEach addCommentScript (all comments)
    Niwango->>Scripts: setComments(all)

    Caller->>Niwango: draw(10)
    Note over Niwango: lastVpos = 10

    Caller->>Niwango: "addComments(comment _vpos=5)"
    Note over Niwango: 5 > 10? NO — drop
    Niwango-->>Caller: (silently ignored)

    Caller->>Niwango: "addComments(comment _vpos=10)"
    Note over Niwango: 10 > 10? NO — drop (same-vpos)
    Niwango-->>Caller: (silently ignored)

    Caller->>Niwango: "addComments(comment _vpos=11)"
    Note over Niwango: 11 > 10? YES — keep
    Niwango->>Scripts: addCommentScript (if owner)
    Niwango->>Scripts: setComments([...comments, future])

    Caller->>Niwango: draw(11)
    Note over Niwango: processes vpos 11, triggers handlers
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant Niwango
    participant Scripts as addCommentScript / setComments

    Note over Niwango: constructor — lastVpos = -1
    Caller->>Niwango: new Niwango(el, comments)
    Niwango->>Scripts: forEach addCommentScript (all comments)
    Niwango->>Scripts: setComments(all)

    Caller->>Niwango: draw(10)
    Note over Niwango: lastVpos = 10

    Caller->>Niwango: "addComments(comment _vpos=5)"
    Note over Niwango: 5 > 10? NO — drop
    Niwango-->>Caller: (silently ignored)

    Caller->>Niwango: "addComments(comment _vpos=10)"
    Note over Niwango: 10 > 10? NO — drop (same-vpos)
    Niwango-->>Caller: (silently ignored)

    Caller->>Niwango: "addComments(comment _vpos=11)"
    Note over Niwango: 11 > 10? YES — keep
    Niwango->>Scripts: addCommentScript (if owner)
    Niwango->>Scripts: setComments([...comments, future])

    Caller->>Niwango: draw(11)
    Note over Niwango: processes vpos 11, triggers handlers
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Unify addComments vpos policy"](https://github.com/xpadev-net/niwango.js/commit/232b6c05bbfadb8b9606b2e04686a539803a3c5a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39487525)</sub>

<!-- /greptile_comment -->