### PR TITLE
Test draw rewind snapshot contract

### DIFF
--- a/src/__tests__/niwango.test.ts
+++ b/src/__tests__/niwango.test.ts
@@ -162,6 +162,22 @@ test("draw floors fractional vpos values", () => {
   expect(niwango.draw(1.1)).toBe(true);
 });
 
+test("draw returns false and does not replay same-vpos work", () => {
+  const handlerScript: A_ANY = { type: "Raw", value: "handler" };
+  const handlerScopes = [{}, {}, Core.prototypeScope];
+  const execute = vi.spyOn(Core, "execute").mockReturnValue(undefined);
+  const niwango = new Niwango(document.createElement("div"), [
+    createComment({ no: 1, message: "same-vpos", _vpos: 10, vpos: 10 }),
+  ]);
+  addHandler(handlerScript, handlerScopes, [], 0);
+
+  expect(niwango.draw(10)).toBe(true);
+  expect(execute).toHaveBeenCalledTimes(1);
+
+  expect(niwango.draw(10)).toBe(false);
+  expect(execute).toHaveBeenCalledTimes(1);
+});
+
 test("draw skips huge forward seek windows", () => {
   const niwango = createNiwango();
 
@@ -175,6 +191,24 @@ test("draw limits forward seeks from the current vpos", () => {
   expect(niwango.draw(10)).toBe(true);
   expect(niwango.draw(100_011)).toBe(false);
   expect(niwango.draw(100_012)).toBe(true);
+});
+
+test("draw treats small rewinds under 100 vpos as a no-op draw", () => {
+  const handlerScript: A_ANY = { type: "Raw", value: "handler" };
+  const handlerScopes = [{}, {}, Core.prototypeScope];
+  const execute = vi.spyOn(Core, "execute").mockReturnValue(undefined);
+  const niwango = new Niwango(document.createElement("div"), [
+    createComment({ no: 1, message: "forward", _vpos: 150, vpos: 150 }),
+    createComment({ no: 2, message: "small rewind", _vpos: 175, vpos: 175 }),
+  ]);
+  addHandler(handlerScript, handlerScopes, [], 0);
+
+  expect(niwango.draw(200)).toBe(true);
+  expect(execute).toHaveBeenCalledTimes(2);
+
+  expect(niwango.draw(150)).toBe(true);
+  expect(execute).toHaveBeenCalledTimes(2);
+  expect(currentTime).toBe(175);
 });
 
 test("draw restores processed comment time when rewinding to a snapshot", () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -176,6 +176,7 @@ class Niwango {
 
   private execute(vpos: number) {
     if (vpos < this.lastVpos) {
+      // Small rewinds keep the current execution state and intentionally no-op.
       if (vpos > this.lastVpos - 100) {
         return true;
       }


### PR DESCRIPTION
## Summary
- add regression coverage for same-vpos draw returning false without replaying work
- document and test small rewinds under 100 vpos as no-op draws
- keep existing large rewind snapshot restore contract covered

## Validation
- pnpm vitest run src/__tests__/niwango.test.ts
- pnpm test
- pnpm lint
- pnpm build

## Review
- deep-review local pass: no actionable findings
- independent subagent review: no actionable findings

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds regression coverage for two existing `draw()` behaviours and documents the small-rewind path with an inline comment. No production logic is changed.

- **Same-vpos short-circuit**: a new test confirms `draw(vpos)` returns `false` immediately (and skips `Core.execute`) when `vpos` equals `lastVpos`, exercising the guard at the top of the `draw` method.
- **Small-rewind no-op**: a new test verifies that a rewind of fewer than 100 vpos units (here 200→150) causes `execute()` to return `true` without replaying scripts and without updating `lastVpos`, so `currentTime` stays at the value set by the last task processed during the forward draw (175). The `_draw` render path is still reached, consistent with `draw()` returning `true`.
- **`main.ts` comment**: a one-line comment is added above the small-rewind early-return to explain the intentional behaviour for future readers.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the only production change is a clarifying comment; all new code is in the test suite.

Both new tests correctly trace the existing code paths: the same-vpos guard in draw() and the small-rewind early-return in execute(). The currentTime live-binding assertion follows the established pattern used in the pre-existing snapshot-rewind test. No logic was changed in production code.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/main.ts | Adds an inline comment documenting the intentional no-op behavior of small rewinds; no logic changes. |
| src/__tests__/niwango.test.ts | Two new tests: one for same-vpos returning false without replaying scripts, one for small-rewind (< 100 vpos) preserving execution state while still calling _draw. Assertions are logically correct given the live-binding currentTime export and the no-op return path in execute(). |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["draw(vpos)"] --> B{"lastVpos === vpos?"}
    B -- "yes" --> C["return false\n(same-vpos no-op)"]
    B -- "no" --> D["execute(vpos)"]

    D --> E{"vpos < lastVpos?\n(rewind)"}
    E -- "no (forward)" --> H["canProcessDrawStepWindow?"]
    E -- "yes" --> F{"vpos > lastVpos - 100?\n(small rewind)"}
    F -- "yes" --> G["return true\n(no script replay,\nlastVpos unchanged)"]
    F -- "no (large rewind)" --> J["restoreSnapshot(vpos)\nupdate lastVpos"]
    J --> H

    H -- "false (huge window)" --> K["skipToVpos(vpos)\nreturn false"]
    H -- "true" --> L["process scripts/comments\nfrom lastVpos to vpos"]
    L --> M["lastVpos = vpos\nreturn true"]

    G --> N["_draw(clear)"]
    M --> N
    K --> O["return false"]
    N --> P["return true"]

    style G fill:#ffe0b2
    style C fill:#ffcccc
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["draw(vpos)"] --> B{"lastVpos === vpos?"}
    B -- "yes" --> C["return false\n(same-vpos no-op)"]
    B -- "no" --> D["execute(vpos)"]

    D --> E{"vpos < lastVpos?\n(rewind)"}
    E -- "no (forward)" --> H["canProcessDrawStepWindow?"]
    E -- "yes" --> F{"vpos > lastVpos - 100?\n(small rewind)"}
    F -- "yes" --> G["return true\n(no script replay,\nlastVpos unchanged)"]
    F -- "no (large rewind)" --> J["restoreSnapshot(vpos)\nupdate lastVpos"]
    J --> H

    H -- "false (huge window)" --> K["skipToVpos(vpos)\nreturn false"]
    H -- "true" --> L["process scripts/comments\nfrom lastVpos to vpos"]
    L --> M["lastVpos = vpos\nreturn true"]

    G --> N["_draw(clear)"]
    M --> N
    K --> O["return false"]
    N --> P["return true"]

    style G fill:#ffe0b2
    style C fill:#ffcccc
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["test draw rewind snapshot contract"](https://github.com/xpadev-net/niwango.js/commit/c59017c297f2fd5ac007d29f4c70d854269ff585) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39488631)</sub>

<!-- /greptile_comment -->