### PR TITLE
parse/execute failures observable

### DIFF
--- a/src/__tests__/commentHandler.test.ts
+++ b/src/__tests__/commentHandler.test.ts
@@ -114,4 +114,26 @@ describe("comment handlers", () => {
       secondScript,
     ]);
   });
+
+  test("logs handler execution errors when a reporter is provided", () => {
+    const scopes = [{}, {}, Core.prototypeScope];
+    const error = new Error("handler failed");
+    const reportError = vi.fn();
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {
+      // keep the expected failure out of test output
+    });
+
+    execute.mockImplementation(() => {
+      throw error;
+    });
+
+    addHandler(script, scopes, [], 100, 50);
+    const comment = createComment(120);
+    triggerHandlers(comment, reportError);
+
+    expect(consoleError).toHaveBeenCalledOnce();
+    expect(consoleError).toHaveBeenCalledWith(error);
+    expect(reportError).toHaveBeenCalledOnce();
+    expect(reportError).toHaveBeenCalledWith(error, comment);
+  });
 });

--- a/src/__tests__/niwango.test.ts
+++ b/src/__tests__/niwango.test.ts
@@ -309,6 +309,25 @@ test("draw reports comment handler execute failures through onError", () => {
   expect(console.error).toHaveBeenCalledWith(executeError);
 });
 
+test("draw logs comment handler execute failures once without onError", () => {
+  const executeError = new Error("handler execute failed");
+  const handlerScript: A_ANY = { type: "Raw", value: "handler" };
+  const handlerScopes = [{}, {}, Core.prototypeScope];
+  vi.spyOn(console, "error").mockImplementation(() => undefined);
+  vi.spyOn(Core, "execute").mockImplementation(() => {
+    throw executeError;
+  });
+  const niwango = new Niwango(document.createElement("div"), [
+    createComment({ message: "trigger", _vpos: 10, vpos: 10 }),
+  ]);
+  addHandler(handlerScript, handlerScopes, [], 0);
+
+  expect(niwango.draw(10)).toBe(true);
+
+  expect(console.error).toHaveBeenCalledOnce();
+  expect(console.error).toHaveBeenCalledWith(executeError);
+});
+
 test("draw treats small rewinds under 100 vpos as a no-op draw", () => {
   const handlerScript: A_ANY = { type: "Raw", value: "handler" };
   const handlerScopes = [{}, {}, Core.prototypeScope];

--- a/src/__tests__/niwango.test.ts
+++ b/src/__tests__/niwango.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 import type { Comment } from "@/@types/comment";
 import { comments, currentTime } from "@/context";
 import { addHandler } from "@/contexts/commentHandler";
+import { addQueue } from "@/contexts/queue";
 import { environmentScope, globalScope } from "@/contexts/scope";
 import Niwango from "@/main";
 import { run } from "@/testUtils";
@@ -191,6 +192,116 @@ test("draw limits forward seeks from the current vpos", () => {
   expect(niwango.draw(10)).toBe(true);
   expect(niwango.draw(100_011)).toBe(false);
   expect(niwango.draw(100_012)).toBe(true);
+});
+
+test("constructor reports owner script parse failures through onError", () => {
+  const parseError = new Error("parse failed");
+  const onError = vi.fn();
+  const parseComment = createComment({
+    no: 10,
+    message: "/broken()",
+    _owner: true,
+  });
+  vi.spyOn(console, "error").mockImplementation(() => undefined);
+  vi.spyOn(Core, "parseScript").mockImplementation(() => {
+    throw parseError;
+  });
+
+  expect(
+    () =>
+      new Niwango(document.createElement("div"), [parseComment], { onError }),
+  ).not.toThrow();
+
+  expect(onError).toHaveBeenCalledOnce();
+  expect(onError).toHaveBeenCalledWith({
+    phase: "parse",
+    error: parseError,
+    comment: parseComment,
+  });
+});
+
+test("draw reports owner script execute failures through onError", () => {
+  const executeError = new Error("execute failed");
+  const onError = vi.fn();
+  const ownerScript: A_ANY = { type: "Raw", value: "owner" };
+  vi.spyOn(console, "error").mockImplementation(() => undefined);
+  vi.spyOn(Core, "parseScript").mockReturnValue(ownerScript);
+  vi.spyOn(Core, "execute").mockImplementation(() => {
+    throw executeError;
+  });
+  const niwango = new Niwango(
+    document.createElement("div"),
+    [createComment({ message: "/owner()", _owner: true })],
+    { onError },
+  );
+
+  expect(niwango.draw(0)).toBe(true);
+
+  expect(onError).toHaveBeenCalledOnce();
+  expect(onError).toHaveBeenCalledWith({
+    phase: "execute",
+    error: executeError,
+    source: "script",
+    vpos: 0,
+  });
+});
+
+test("draw reports queued timer execute failures through onError", () => {
+  const executeError = new Error("queued execute failed");
+  const onError = vi.fn();
+  const schedulerScript: A_ANY = { type: "Raw", value: "scheduler" };
+  const queuedScript: A_ANY = { type: "Raw", value: "queued" };
+  vi.spyOn(console, "error").mockImplementation(() => undefined);
+  vi.spyOn(Core, "parseScript").mockReturnValue(schedulerScript);
+  vi.spyOn(Core, "execute").mockImplementation((script, scopes, trace) => {
+    if (script === queuedScript) {
+      throw executeError;
+    }
+    addQueue(queuedScript, 0, scopes, trace);
+    return undefined;
+  });
+  const niwango = new Niwango(
+    document.createElement("div"),
+    [createComment({ message: "/timer(0, lambda(fail()))", _owner: true })],
+    { onError },
+  );
+
+  expect(niwango.draw(1)).toBe(true);
+
+  expect(onError).toHaveBeenCalledOnce();
+  expect(onError).toHaveBeenCalledWith({
+    phase: "execute",
+    error: executeError,
+    source: "queue",
+    vpos: 0,
+  });
+});
+
+test("draw reports comment handler execute failures through onError", () => {
+  const executeError = new Error("handler execute failed");
+  const onError = vi.fn();
+  const handlerScript: A_ANY = { type: "Raw", value: "handler" };
+  const handlerScopes = [{}, {}, Core.prototypeScope];
+  vi.spyOn(console, "error").mockImplementation(() => undefined);
+  vi.spyOn(Core, "execute").mockImplementation(() => {
+    throw executeError;
+  });
+  const niwango = new Niwango(
+    document.createElement("div"),
+    [createComment({ message: "trigger", _vpos: 10, vpos: 10 })],
+    { onError },
+  );
+  addHandler(handlerScript, handlerScopes, [], 0);
+
+  expect(niwango.draw(10)).toBe(true);
+
+  expect(onError).toHaveBeenCalledOnce();
+  expect(onError).toHaveBeenCalledWith({
+    phase: "execute",
+    error: executeError,
+    source: "commentHandler",
+    vpos: 10,
+  });
 });
 
 test("draw treats small rewinds under 100 vpos as a no-op draw", () => {

--- a/src/__tests__/niwango.test.ts
+++ b/src/__tests__/niwango.test.ts
@@ -218,6 +218,7 @@ test("constructor reports owner script parse failures through onError", () => {
     error: parseError,
     comment: parseComment,
   });
+  expect(console.error).not.toHaveBeenCalled();
 });
 
 test("draw reports owner script execute failures through onError", () => {
@@ -244,6 +245,7 @@ test("draw reports owner script execute failures through onError", () => {
     source: "script",
     vpos: 0,
   });
+  expect(console.error).not.toHaveBeenCalled();
 });
 
 test("draw reports queued timer execute failures through onError", () => {
@@ -275,6 +277,7 @@ test("draw reports queued timer execute failures through onError", () => {
     source: "queue",
     vpos: 0,
   });
+  expect(console.error).not.toHaveBeenCalled();
 });
 
 test("draw reports comment handler execute failures through onError", () => {
@@ -302,6 +305,8 @@ test("draw reports comment handler execute failures through onError", () => {
     source: "commentHandler",
     vpos: 10,
   });
+  expect(console.error).toHaveBeenCalledOnce();
+  expect(console.error).toHaveBeenCalledWith(executeError);
 });
 
 test("draw treats small rewinds under 100 vpos as a no-op draw", () => {

--- a/src/contexts/commentHandler.ts
+++ b/src/contexts/commentHandler.ts
@@ -8,6 +8,8 @@ import { getGlobalScope } from "@/utils/utils";
 
 let handlers: IHandler[] = [];
 
+type HandlerErrorReporter = (error: unknown, comment: Comment) => void;
+
 const resetHandlers = () => {
   handlers = [];
 };
@@ -46,7 +48,10 @@ const setHandlers = (newHandlers: IHandler[]) => {
   handlers = newHandlers;
 };
 
-const triggerHandlers = (comment: Comment) => {
+const triggerHandlers = (
+  comment: Comment,
+  reportError?: HandlerErrorReporter,
+) => {
   removeExpiredHandlers(comment._vpos);
   if (comment.message.startsWith("/")) return;
   for (const handler of handlers) {
@@ -56,7 +61,11 @@ const triggerHandlers = (comment: Comment) => {
     try {
       Core.execute(handler.script, handler.scopes, [handler.script]);
     } catch (e) {
-      console.error(e);
+      if (reportError) {
+        reportError(e, comment);
+      } else {
+        console.error(e);
+      }
     }
   }
 };

--- a/src/contexts/commentHandler.ts
+++ b/src/contexts/commentHandler.ts
@@ -61,11 +61,8 @@ const triggerHandlers = (
     try {
       Core.execute(handler.script, handler.scopes, [handler.script]);
     } catch (e) {
-      if (reportError) {
-        reportError(e, comment);
-      } else {
-        console.error(e);
-      }
+      console.error(e);
+      reportError?.(e, comment);
     }
   }
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export type { Comment } from "./@types/comment";
+export type { NiwangoErrorEvent, NiwangoOptions } from "./main";
 export { default } from "./main";

--- a/src/main.ts
+++ b/src/main.ts
@@ -62,7 +62,46 @@ const normalizeComments = (commentInputs: unknown) => {
   return normalizedComments;
 };
 
-const addCommentScript = (comment: Comment) => {
+type NiwangoParseErrorEvent = {
+  phase: "parse";
+  error: unknown;
+  comment: Comment;
+};
+
+type NiwangoExecuteErrorEvent = {
+  phase: "execute";
+  error: unknown;
+  source: "script" | "queue" | "commentHandler";
+  vpos: number;
+};
+
+export type NiwangoErrorEvent =
+  | NiwangoParseErrorEvent
+  | NiwangoExecuteErrorEvent;
+
+export type NiwangoOptions = {
+  onError?: (event: NiwangoErrorEvent) => void;
+};
+
+const reportError = (
+  onError: NiwangoOptions["onError"],
+  event: NiwangoErrorEvent,
+) => {
+  console.error(event.error);
+  if (!onError) {
+    return;
+  }
+  try {
+    onError(event);
+  } catch (e) {
+    console.error(e);
+  }
+};
+
+const addCommentScript = (
+  comment: Comment,
+  onError?: NiwangoOptions["onError"],
+) => {
   if (comment.message.match(/^\//) && comment._owner) {
     try {
       const ast = {
@@ -71,7 +110,7 @@ const addCommentScript = (comment: Comment) => {
       };
       addScript(ast, comment._vpos);
     } catch (e) {
-      console.error(e);
+      reportError(onError, { phase: "parse", error: e, comment });
     }
   }
 };
@@ -132,19 +171,24 @@ const createRender = (targetElement: unknown): IRender => {
 
 class Niwango {
   private readonly render: IRender;
+  private readonly onError?: NiwangoOptions["onError"];
   static default = Niwango;
   private lastVpos: number;
   constructor(
     targetElement: HTMLCanvasElement | HTMLDivElement,
     comments: Comment[],
+    options: NiwangoOptions = {},
   ) {
     setup();
     initConfig();
     this.render = createRender(targetElement);
+    this.onError = options.onError;
     this.lastVpos = -1;
 
     const normalizedComments = normalizeComments(comments);
-    normalizedComments.forEach(addCommentScript);
+    normalizedComments.forEach((comment) => {
+      addCommentScript(comment, this.onError);
+    });
     setComments(normalizedComments);
     setCurrentTime(-1);
     setRender(this.render);
@@ -213,7 +257,14 @@ class Niwango {
             config.stageWidth[environmentScope.isWide ? "full" : "default"];
         }
         if (queue.type === "comment") {
-          triggerHandlers(queue.comment);
+          triggerHandlers(queue.comment, (error, comment) => {
+            reportError(this.onError, {
+              phase: "execute",
+              error,
+              source: "commentHandler",
+              vpos: comment._vpos,
+            });
+          });
           continue;
         }
         try {
@@ -229,7 +280,12 @@ class Niwango {
             trace,
           );
         } catch (e) {
-          console.error(e);
+          reportError(this.onError, {
+            phase: "execute",
+            error: e,
+            source: queue.type,
+            vpos: queue.time,
+          });
         }
         tasks.sort(nativeSort("time"));
       }
@@ -257,7 +313,9 @@ class Niwango {
     const futureComments = normalizedComments.filter(
       (comment) => comment._vpos > this.lastVpos,
     );
-    futureComments.forEach(addCommentScript);
+    futureComments.forEach((comment) => {
+      addCommentScript(comment, this.onError);
+    });
     setComments([...comments, ...futureComments]);
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -257,14 +257,17 @@ class Niwango {
             config.stageWidth[environmentScope.isWide ? "full" : "default"];
         }
         if (queue.type === "comment") {
-          triggerHandlers(queue.comment, (error, comment) => {
-            reportError(this.onError, {
-              phase: "execute",
-              error,
-              source: "commentHandler",
-              vpos: comment._vpos,
-            });
-          });
+          const reportHandlerError = this.onError
+            ? (error: unknown, comment: Comment) => {
+                reportError(this.onError, {
+                  phase: "execute",
+                  error,
+                  source: "commentHandler",
+                  vpos: comment._vpos,
+                });
+              }
+            : undefined;
+          triggerHandlers(queue.comment, reportHandlerError);
           continue;
         }
         try {

--- a/src/main.ts
+++ b/src/main.ts
@@ -87,8 +87,8 @@ const reportError = (
   onError: NiwangoOptions["onError"],
   event: NiwangoErrorEvent,
 ) => {
-  console.error(event.error);
   if (!onError) {
+    console.error(event.error);
     return;
   }
   try {


### PR DESCRIPTION
## チケットへのリンク

* P2 `parse/execute 失敗を API 利用者が観測できるようにする`

## やったこと

* `Niwango` constructor に任意の `onError` オプションを追加
* owner script の parse 失敗、script/queue/comment handler の execute 失敗を `onError` で観測できるようにした
* 既存の `console.error` と `draw()` の戻り値挙動は維持
* parse/script/queue/comment handler の失敗観測テストを追加

## やらないこと

* 例外を再throwするモードや result object 化は追加しない
* event loop や render/object 内部の再設計は行わない

## できるようになること（ユーザ目線）

* API 利用者が `onError` callback で parse/execute 失敗を検知できる

## できなくなること（ユーザ目線）

* 無し

## 動作確認

* `pnpm vitest run src/__tests__/niwango.test.ts src/__tests__/commentHandler.test.ts` 成功
* `pnpm test` 成功
* `pnpm lint` 成功
* `pnpm build` 成功
* pre-commit hook 成功（biome-check / check-types / test）

## その他

* public API は任意 callback の追加のみで、既存 constructor 呼び出しとの互換性を維持しています。

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds an optional `onError` callback to the `Niwango` constructor (`NiwangoOptions`) that lets API consumers observe parse and execute failures without changing the existing `console.error` / `draw()` return-value semantics. The new types `NiwangoErrorEvent` and `NiwangoOptions` are re-exported from `src/index.ts` and covered by new unit tests.

- **`src/main.ts`**: Introduces `NiwangoErrorEvent` (discriminated union of parse / execute phases), `NiwangoOptions`, and a module-local `reportError` helper that either logs to `console.error` (no callback) or calls `onError` (with callback, catching any throw). All three execute paths — owner-script parse, script/queue execute, and comment-handler execute — now route through this helper.
- **`src/contexts/commentHandler.ts`**: `triggerHandlers` gains an optional `HandlerErrorReporter` parameter; `console.error` is still called unconditionally in its catch block (before the optional callback), making comment-handler error reporting behave differently from the other paths.
- **Tests**: New cases in `niwango.test.ts` and `commentHandler.test.ts` verify each error path, including that `console.error` fires once even when `onError` is present for comment-handler errors.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is purely additive, the optional third parameter preserves all existing call sites, and the test suite covers every new error path.

All changed code paths are backward-compatible additions. The reportError helper correctly falls back to console.error when no callback is set, existing constructor calls remain valid, and the new tests exercise each error branch end-to-end.

src/contexts/commentHandler.ts — the unconditional console.error call before the optional reporter makes comment-handler error reporting behave differently from the script/queue paths, which is covered in the previous review threads.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/main.ts | Adds NiwangoErrorEvent, NiwangoOptions, and reportError helper; routes parse/script/queue errors through reportError, and comment-handler errors via a conditional callback to triggerHandlers. |
| src/contexts/commentHandler.ts | triggerHandlers accepts an optional HandlerErrorReporter; console.error remains unconditional before the optional callback, producing different behavior from the other error paths. |
| src/index.ts | Re-exports new public types NiwangoErrorEvent and NiwangoOptions; no logic changes. |
| src/__tests__/niwango.test.ts | Adds five new integration tests covering parse, script execute, queue execute, and comment-handler execute failure paths, including a no-onError baseline for comment-handler logging. |
| src/__tests__/commentHandler.test.ts | Adds unit test confirming that triggerHandlers calls both console.error and the reporter callback when a reporter is provided. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Niwango constructor / addComments] -->|owner script| B[addCommentScript]
    B -->|parse throws| C{onError set?}
    C -->|no| D[console.error]
    C -->|yes| E[onError phase:parse]

    F[draw → execute loop] -->|queue.type === comment| G[triggerHandlers optional reportHandlerError]
    G -->|handler throws| H[console.error unconditional]
    H -->|reportHandlerError?| I{onError set?}
    I -->|yes| J[onError phase:execute source:commentHandler]
    I -->|no| K[no-op]

    F -->|queue.type === script/queue| L[Core.execute]
    L -->|throws| M[reportError helper]
    M -->|onError absent| N[console.error]
    M -->|onError present| O[onError phase:execute source:script/queue]
    M -->|onError throws| P[console.error onError exception]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Niwango constructor / addComments] -->|owner script| B[addCommentScript]
    B -->|parse throws| C{onError set?}
    C -->|no| D[console.error]
    C -->|yes| E[onError phase:parse]

    F[draw → execute loop] -->|queue.type === comment| G[triggerHandlers optional reportHandlerError]
    G -->|handler throws| H[console.error unconditional]
    H -->|reportHandlerError?| I{onError set?}
    I -->|yes| J[onError phase:execute source:commentHandler]
    I -->|no| K[no-op]

    F -->|queue.type === script/queue| L[Core.execute]
    L -->|throws| M[reportError helper]
    M -->|onError absent| N[console.error]
    M -->|onError present| O[onError phase:execute source:script/queue]
    M -->|onError throws| P[console.error onError exception]
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["Avoid duplicate handler error logging"](https://github.com/xpadev-net/niwango.js/commit/df6eaf0a08f28ceca4381253b8628db64df9cecc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39491152)</sub>

<!-- /greptile_comment -->